### PR TITLE
Add as_u8 function to flags and to choose COSE key type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/src/auth_data.rs
+++ b/src/auth_data.rs
@@ -20,6 +20,24 @@ impl Flags {
         };
         Ok(flags)
     }
+
+    pub fn as_u8(&self) -> u8 {
+        let mut ret = 0x0;
+        if self.user_present_result {
+            ret = ret | 0x01;
+        }
+        if self.user_verified_result {
+            ret = ret | 0x04;
+        }
+        if self.attested_credential_data_included {
+            ret = ret | 0x40;
+        }
+        if self.extension_data_included {
+            ret = ret | 0x80;
+        }
+    
+        ret
+    }
 }
 
 impl fmt::Display for Flags {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,22 @@ pub fn make_credential(
 ) -> Result<make_credential_params::Attestation> {
     let device = get_device(cfg)?;
     make_credential::make_credential(
-        &device, rpid, challenge, pin, false, None, /*None,*/ None,
+        &device, rpid, challenge, pin, false, None, /*None,*/ None, None,
+    )
+}
+
+/// Registration command. Generate credentials (with PIN, non Resident Key) while also
+/// specifying the type of key you'd like to create.
+pub fn make_credential_with_key_type(
+    cfg: &LibCfg,
+    rpid: &str,
+    challenge: &[u8],
+    pin: Option<&str>,
+    key_type: Option<make_credential_params::CredentialSupportedKeyType>,
+) -> Result<make_credential_params::Attestation> {
+    let device = get_device(cfg)?;
+    make_credential::make_credential(
+        &device, rpid, challenge, pin, false, None, /*None,*/ None, key_type,
     )
 }
 
@@ -297,7 +312,7 @@ pub fn make_credential_with_extensions(
 ) -> Result<make_credential_params::Attestation> {
     let device = get_device(cfg)?;
     make_credential::make_credential(
-        &device, rpid, challenge, pin, false, None, /*None,*/ extensions,
+        &device, rpid, challenge, pin, false, None, /*None,*/ extensions, None,
     )
 }
 
@@ -319,6 +334,7 @@ pub fn make_credential_rk(
         Some(rkparam),
         //None,
         None,
+        None,
     )
 }
 
@@ -330,7 +346,7 @@ pub fn make_credential_without_pin(
 ) -> Result<make_credential_params::Attestation> {
     let device = get_device(cfg)?;
     make_credential::make_credential(
-        &device, rpid, challenge, None, false, None, /*None,*/ None,
+        &device, rpid, challenge, None, false, None, /*None,*/ None, None,
     )
 }
 

--- a/src/make_credential.rs
+++ b/src/make_credential.rs
@@ -3,7 +3,7 @@ use crate::ctaphid;
 use crate::enc_hmac_sha_256;
 use crate::make_credential_command;
 use crate::make_credential_params;
-use crate::make_credential_params::Extension;
+use crate::make_credential_params::{CredentialSupportedKeyType, Extension};
 use crate::make_credential_response;
 use crate::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
 use crate::FidoKeyHid;
@@ -22,6 +22,7 @@ pub fn make_credential(
     rkparam: Option<&PublicKeyCredentialUserEntity>,
     //uv: Option<bool>,
     extensions: Option<&Vec<Extension>>,
+    key_type: Option<CredentialSupportedKeyType>,
 ) -> Result<make_credential_params::Attestation> {
     // init
     let cid = ctaphid::ctaphid_init(device).map_err(Error::msg)?;
@@ -47,6 +48,7 @@ pub fn make_credential(
         let mut params = make_credential_command::Params::new(rpid, challenge.to_vec(), user_id);
         params.option_rk = rk;
         params.option_uv = uv;
+        params.key_type = key_type.unwrap_or(CredentialSupportedKeyType::Ecdsa256);
 
         if let Some(rkp) = rkparam {
             params.user_name = rkp.name.to_string();

--- a/src/make_credential_command.rs
+++ b/src/make_credential_command.rs
@@ -1,9 +1,10 @@
 use crate::ctapdef;
-use crate::make_credential_params::Extension;
+use crate::make_credential_params::{CredentialSupportedKeyType, Extension};
 use crate::util;
 use serde_cbor::to_vec;
 use serde_cbor::Value;
 use std::collections::BTreeMap;
+
 
 #[derive(Debug, Default)]
 pub struct Params {
@@ -17,6 +18,7 @@ pub struct Params {
     pub option_uv: Option<bool>,
     pub client_data_hash: Vec<u8>,
     pub pin_auth: Vec<u8>,
+    pub key_type: CredentialSupportedKeyType,
 }
 
 impl Params {
@@ -25,6 +27,7 @@ impl Params {
             rp_id: rp_id.to_string(),
             user_id: user_id.to_vec(),
             client_data_hash: util::create_clientdata_hash(challenge),
+            key_type: CredentialSupportedKeyType::Ecdsa256,
             ..Default::default()
         }
     }
@@ -88,7 +91,7 @@ pub fn create_payload(params: Params, extensions: Option<&Vec<Extension>>) -> Ve
 
     // 0x04 : pubKeyCredParams
     let mut pub_key_cred_params_val = BTreeMap::new();
-    pub_key_cred_params_val.insert(Value::Text("alg".to_string()), Value::Integer(-7));
+    pub_key_cred_params_val.insert(Value::Text("alg".to_string()), Value::Integer(params.key_type as i128));
     pub_key_cred_params_val.insert(
         Value::Text("type".to_string()),
         Value::Text("public-key".to_string()),

--- a/src/make_credential_params.rs
+++ b/src/make_credential_params.rs
@@ -75,3 +75,15 @@ pub enum Extension {
     #[strum(serialize = "hmac-secret")]
     HmacSecret(Option<bool>),
 }
+
+#[derive(Debug)]
+pub enum CredentialSupportedKeyType {
+    Ecdsa256 = -7,
+    Ed25519 = -8,
+}
+
+impl std::default::Default for CredentialSupportedKeyType {
+    fn default() -> Self {
+        Self::Ecdsa256
+    }
+}


### PR DESCRIPTION
Sometimes you need to re-serialize the data so this adds a simple way to get the flags as a `u8`.

I also need the ability to choose at runtime between generating Ecdsa or Ed25519 keys so this adds a way to do that. Not clear if there was already a way to do this that I missed or if a better way exists.