### PR TITLE
Add build tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,27 @@
+name: macOS + Ubuntu
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  macos-build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --examples --verbose
+  
+  ubuntu-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --examples --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --examples --verbose
+      run: cargo build --verbose
   
   ubuntu-build:
     runs-on: ubuntu-latest
@@ -24,4 +24,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --examples --verbose
+      run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,5 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt install -y libusb-1.0-0-dev libudev-dev
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
Splitting this out from the large PR.

Adds tests to ensure the code builds correctly on macOS and Ubuntu operating systems. This should catch any breakage on macOS and Raspberry Pi OS/Linux systems.