### PR TITLE
 decrypt hmac-secret response

### DIFF
--- a/src/get_assertion_response.rs
+++ b/src/get_assertion_response.rs
@@ -55,7 +55,6 @@ fn parse_cbor_authdata(
     if ass.flags.extension_data_included {
         //println!("{:02} - {:?}", slice.len(), util::to_hex_str(&slice));
         let maps = util::cbor_bytes_to_map(&slice)?;
-        let shared_secret = shared_secret.map(|secret| secret);
         for (key, val) in &maps {
             if let Value::Text(member) = key {
                 if *member == Extension::HmacSecret(None).to_string() {


### PR DESCRIPTION
As per spec the hmac-secret response is encrypted with the shared secret, this PR adds the necessary decryption logic.

```
The authenticator returns output1 and, when there were two salts, output2 encrypted to the platform using [sharedSecret](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#platformSharedSecret) as part of "extensions" parameter:
```