### PR TITLE
Add option to add credentials to the `excludeList`

### DIFF
--- a/src/fidokey/make_credential/make_credential_params.rs
+++ b/src/fidokey/make_credential/make_credential_params.rs
@@ -99,6 +99,7 @@ pub struct MakeCredentialArgs<'a> {
     pub pin: Option<&'a str>,
     pub key_type: Option<CredentialSupportedKeyType>,
     pub uv: Option<bool>,
+    pub exclude_list: Vec<Vec<u8>>,
     pub rkparam: Option<PublicKeyCredentialUserEntity>,
     pub extensions: Option<Vec<Mext>>,
 }
@@ -115,6 +116,7 @@ pub struct MakeCredentialArgsBuilder<'a> {
     pin: Option<&'a str>,
     key_type: Option<CredentialSupportedKeyType>,
     uv: Option<bool>,
+    exclude_list: Vec<Vec<u8>>,
     rkparam: Option<PublicKeyCredentialUserEntity>,
     extensions: Option<Vec<Mext>>,
 }
@@ -138,6 +140,13 @@ impl<'a> MakeCredentialArgsBuilder<'a> {
     pub fn without_pin_and_uv(mut self) -> MakeCredentialArgsBuilder<'a> {
         self.pin = None;
         self.uv = None;
+        self
+    }
+
+    /// Adds an credential_id to the excludeList, preventing further credentials being created on
+    /// the same authenticator
+    pub fn exclude_authenticator(mut self, credential_id: &[u8]) -> MakeCredentialArgsBuilder<'a> {
+        self.exclude_list.push(credential_id.to_vec());
         self
     }
 
@@ -169,6 +178,7 @@ impl<'a> MakeCredentialArgsBuilder<'a> {
             pin: self.pin,
             key_type: self.key_type,
             uv: self.uv,
+            exclude_list: self.exclude_list,
             rkparam: self.rkparam,
             extensions: self.extensions,
         }

--- a/src/fidokey/make_credential/mod.rs
+++ b/src/fidokey/make_credential/mod.rs
@@ -40,6 +40,7 @@ impl FidoKeyHid {
             false,
             None,
             should_uv(pin),
+            &[],
             None,
             None,
         )
@@ -61,6 +62,7 @@ impl FidoKeyHid {
             false,
             None,
             should_uv(pin),
+            &[],
             None,
             key_type,
         )
@@ -80,6 +82,7 @@ impl FidoKeyHid {
             false,
             None,
             should_uv(pin),
+            &[],
             extensions,
             None,
         )
@@ -100,6 +103,7 @@ impl FidoKeyHid {
             true,
             Some(rkparam),
             should_uv(pin),
+            &[],
             None,
             None,
         )
@@ -125,6 +129,7 @@ impl FidoKeyHid {
             rk,
             rk_param,
             args.uv,
+            &args.exclude_list,
             extensions,
             args.key_type,
         )
@@ -138,6 +143,7 @@ impl FidoKeyHid {
         rk: bool,
         rkparam: Option<&PublicKeyCredentialUserEntity>,
         uv: Option<bool>,
+        exclude_list: &[Vec<u8>],
         extensions: Option<&Vec<Mext>>,
         key_type: Option<CredentialSupportedKeyType>,
     ) -> Result<make_credential_params::Attestation> {
@@ -157,6 +163,7 @@ impl FidoKeyHid {
             let mut params = make_credential_command::Params::new(rpid, challenge.to_vec(), user_id);
             params.option_rk = rk;
             params.option_uv = uv;
+            params.exclude_list = exclude_list.to_vec();
             params.key_type = key_type.unwrap_or(CredentialSupportedKeyType::Ecdsa256);
     
             if let Some(rkp) = rkparam {


### PR DESCRIPTION
Adds functionality to the MakeCredentialBuilder and interal functions to add credentials to the excludeList which prevents authenticators from generating a new credential if they've already generated one contained in the excludeList. 