### PR TITLE
Do not require an resident key to use an user entity

### DIFF
--- a/examples/test-with-pin-non-rk/main.rs
+++ b/examples/test-with-pin-non-rk/main.rs
@@ -6,7 +6,7 @@ use ctap_hid_fido2::{
         AssertionExtension as Gext, CredentialExtension as Mext, CredentialSupportedKeyType,
         GetAssertionArgsBuilder, MakeCredentialArgsBuilder,
     },
-    get_fidokey_devices, util, verifier, Cfg, FidoKeyHid, FidoKeyHidFactory,
+    get_fidokey_devices, util, verifier, Cfg, FidoKeyHid, FidoKeyHidFactory, public_key_credential_user_entity::PublicKeyCredentialUserEntity,
 };
 
 fn main() -> Result<()> {
@@ -69,9 +69,12 @@ fn non_discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -> R
 
     println!("- Register");
     let challenge = verifier::create_challenge();
+    let user_entity =
+        PublicKeyCredentialUserEntity::new(Some(b"2222"), Some("gebo"), Some("GEBO GEBO"));
 
     let make_credential_args = MakeCredentialArgsBuilder::new(&rpid, &challenge)
         .pin(pin)
+        .user_entity(&user_entity)
         .build();
 
     let attestation = device.make_credential_with_args(&make_credential_args)?;

--- a/examples/test-with-pin-rk/main.rs
+++ b/examples/test-with-pin-rk/main.rs
@@ -58,7 +58,7 @@ fn discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -> Resul
 
     println!("- Register");
     let challenge = verifier::create_challenge();
-    let rkparam =
+    let user_entity =
         PublicKeyCredentialUserEntity::new(Some(b"1111"), Some("gebo"), Some("GEBO GEBO"));
 
     let mut strbuf = StrBuf::new(20);
@@ -67,13 +67,14 @@ fn discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -> Resul
         strbuf
             .append("- rpid", &rpid)
             .appenh("- challenge", &challenge)
-            .append("- rkparam", &rkparam)
+            .append("- user_entity", &user_entity)
             .build()
     );
 
     let make_credential_args = MakeCredentialArgsBuilder::new(&rpid, &challenge)
         .pin(pin)
-        .rkparam(&rkparam)
+        .user_entity(&user_entity)
+        .resident_key()
         .build();
 
     let attestation = device.make_credential_with_args(&make_credential_args)?;
@@ -124,7 +125,7 @@ fn with_cred_blob_ex(device: &FidoKeyHid, rpid: &str, pin: &str) -> Result<()> {
 
     println!("- Register");
     let challenge = verifier::create_challenge();
-    let rkparam = PublicKeyCredentialUserEntity::new(
+    let user_entity = PublicKeyCredentialUserEntity::new(
         Some(b"2222"),
         Some("cred blob ex"),
         Some("CRED BLOB EXTENSION"),
@@ -138,13 +139,13 @@ fn with_cred_blob_ex(device: &FidoKeyHid, rpid: &str, pin: &str) -> Result<()> {
         strbuf
             .append("- rpid", &rpid)
             .appenh("- challenge", &challenge)
-            .append("- rkparam", &rkparam)
+            .append("- user_entity", &user_entity)
             .build()
     );
 
     let make_credential_args = MakeCredentialArgsBuilder::new(&rpid, &challenge)
         .pin(pin)
-        .rkparam(&rkparam)
+        .user_entity(&user_entity)
         .extensions(&vec![protect, blob])
         .build();
 
@@ -250,9 +251,9 @@ fn legacy_discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -
 
     println!("- Register");
     let challenge = verifier::create_challenge();
-    let rkparam =
+    let user_entity =
         PublicKeyCredentialUserEntity::new(Some(b"1111"), Some("gebo"), Some("GEBO GEBO"));
-    //let rkparam = PublicKeyCredentialUserEntity::new(Some(b"2222"),Some("gebo-2"),Some("GEBO GEBO-2"));
+    //let user_entity = PublicKeyCredentialUserEntity::new(Some(b"2222"),Some("gebo-2"),Some("GEBO GEBO-2"));
 
     let mut strbuf = StrBuf::new(20);
     println!(
@@ -260,11 +261,11 @@ fn legacy_discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -
         strbuf
             .append("- rpid", &rpid)
             .appenh("- challenge", &challenge)
-            .append("- rkparam", &rkparam)
+            .append("- user_entity", &user_entity)
             .build()
     );
 
-    let attestation = device.make_credential_rk(rpid, &challenge, Some(pin), &rkparam)?;
+    let attestation = device.make_credential_rk(rpid, &challenge, Some(pin), &user_entity)?;
 
     println!("-- Register Success");
     debug!("Attestation");

--- a/src/fidokey/make_credential/make_credential_command.rs
+++ b/src/fidokey/make_credential/make_credential_command.rs
@@ -149,7 +149,7 @@ pub fn create_payload(params: Params, extensions: Option<&Vec<Extension>>) -> Ve
 
     /*
     let user_id = {
-        if let Some(rkp) = rkparam {
+        if let Some(rkp) = user_entity {
             rkp.id.to_vec()
         } else {
             [].to_vec()

--- a/src/fidokey/make_credential/make_credential_params.rs
+++ b/src/fidokey/make_credential/make_credential_params.rs
@@ -96,7 +96,8 @@ pub struct MakeCredentialArgs<'a> {
     pub key_type: Option<CredentialSupportedKeyType>,
     pub uv: Option<bool>,
     pub exclude_list: Vec<Vec<u8>>,
-    pub rkparam: Option<PublicKeyCredentialUserEntity>,
+    pub user_entity: Option<PublicKeyCredentialUserEntity>,
+    pub rk: Option<bool>,
     pub extensions: Option<Vec<Mext>>,
 }
 impl<'a> MakeCredentialArgs<'a> {
@@ -113,7 +114,8 @@ pub struct MakeCredentialArgsBuilder<'a> {
     key_type: Option<CredentialSupportedKeyType>,
     uv: Option<bool>,
     exclude_list: Vec<Vec<u8>>,
-    rkparam: Option<PublicKeyCredentialUserEntity>,
+    user_entity: Option<PublicKeyCredentialUserEntity>,
+    rk: Option<bool>,
     extensions: Option<Vec<Mext>>,
 }
 
@@ -160,11 +162,16 @@ impl<'a> MakeCredentialArgsBuilder<'a> {
         self
     }
 
-    pub fn rkparam(
+    pub fn user_entity(
         mut self,
-        rkparam: &PublicKeyCredentialUserEntity,
+        user_entity: &PublicKeyCredentialUserEntity,
     ) -> MakeCredentialArgsBuilder<'a> {
-        self.rkparam = Some(rkparam.clone());
+        self.user_entity = Some(user_entity.clone());
+        self
+    }
+
+    pub fn resident_key(mut self) -> MakeCredentialArgsBuilder<'a> {
+        self.rk = Some(true);
         self
     }
 
@@ -176,7 +183,8 @@ impl<'a> MakeCredentialArgsBuilder<'a> {
             key_type: self.key_type,
             uv: self.uv,
             exclude_list: self.exclude_list,
-            rkparam: self.rkparam,
+            user_entity: self.user_entity,
+            rk: self.rk,
             extensions: self.extensions,
         }
     }

--- a/src/fidokey/make_credential/mod.rs
+++ b/src/fidokey/make_credential/mod.rs
@@ -20,7 +20,7 @@ impl FidoKeyHid {
         let cid = ctaphid::ctaphid_init(self)?;
 
         let user_id = {
-            if let Some(rkp) = &args.rkparam {
+            if let Some(rkp) = &args.user_entity{
                 rkp.id.to_vec()
             } else {
                 [].to_vec()
@@ -32,7 +32,7 @@ impl FidoKeyHid {
             let mut params =
                 make_credential_command::Params::new(&args.rpid, args.challenge.to_vec(), user_id);
 
-            params.option_rk = args.rkparam.is_some();
+            params.option_rk = args.rk.unwrap_or(false);
 
             params.option_uv = if let Some(uv) = args.uv {
                 Some(uv)
@@ -45,7 +45,7 @@ impl FidoKeyHid {
                 .key_type
                 .unwrap_or(CredentialSupportedKeyType::Ecdsa256);
 
-            if let Some(rkp) = &args.rkparam {
+            if let Some(rkp) = &args.user_entity {
                 params.user_name = rkp.name.to_string();
                 params.user_display_name = rkp.display_name.to_string();
             }
@@ -137,9 +137,9 @@ impl FidoKeyHid {
         rpid: &str,
         challenge: &[u8],
         pin: Option<&str>,
-        rkparam: &PublicKeyCredentialUserEntity,
+        user_entity: &PublicKeyCredentialUserEntity,
     ) -> Result<Attestation> {
-        let mut builder = MakeCredentialArgsBuilder::new(rpid, challenge).rkparam(rkparam);
+        let mut builder = MakeCredentialArgsBuilder::new(rpid, challenge).user_entity(user_entity);
 
         if let Some(pin) = pin {
             builder = builder.pin(pin);


### PR DESCRIPTION
Hi,

I've just come across the fact that the library  is creating an resident key whenever an `PublicKeyCredentialUserEntity` is specified that however the spec also allows for credentials to be created with an `PublicKeyCredentialUserEntity` without them being resident keys. Since specifying an `PublicKeyCredentialUserEntity` is still useful if the authenticator used possesses an display in which case the username can be displayed during an assertion.

Aside from that I'd consider it an bad practice to create an resident implicitly since resident keys pose privacy issues. I therefore propose to separate the creation of an resident key from supplying an `PublicKeyCredentialUserEntity` by renaming `rkparam` to `user_entity` and adding an additional `resident_key` flag.