### PR TITLE
Allow  multiple key_types in make_credential

### DIFF
--- a/src/fidokey/make_credential/make_credential_command.rs
+++ b/src/fidokey/make_credential/make_credential_command.rs
@@ -18,7 +18,7 @@ pub struct Params {
     pub option_uv: Option<bool>,
     pub client_data_hash: Vec<u8>,
     pub pin_auth: Vec<u8>,
-    pub key_type: CredentialSupportedKeyType,
+    pub key_type: Vec<CredentialSupportedKeyType>,
 }
 
 impl Params {
@@ -27,7 +27,7 @@ impl Params {
             rp_id: rp_id.to_string(),
             user_id: user_id.to_vec(),
             client_data_hash: util::create_clientdata_hash(challenge),
-            key_type: CredentialSupportedKeyType::Ecdsa256,
+            key_type: vec![CredentialSupportedKeyType::Ecdsa256],
             ..Default::default()
         }
     }
@@ -90,17 +90,24 @@ pub fn create_payload(params: Params, extensions: Option<&Vec<Extension>>) -> Ve
     let user = Value::Map(user_val);
 
     // 0x04 : pubKeyCredParams
-    let mut pub_key_cred_params_val = BTreeMap::new();
-    pub_key_cred_params_val.insert(
-        Value::Text("alg".to_string()),
-        Value::Integer(params.key_type as i128),
-    );
-    pub_key_cred_params_val.insert(
-        Value::Text("type".to_string()),
-        Value::Text("public-key".to_string()),
-    );
-    let tmp = Value::Map(pub_key_cred_params_val);
-    let pub_key_cred_params = Value::Array(vec![tmp]);
+    let pub_key_cred_params_vec = params
+        .key_type
+        .iter()
+        .map(|key_type| {
+            let mut pub_key_cred_params_val = BTreeMap::new();
+            pub_key_cred_params_val.insert(
+                Value::Text("alg".to_string()),
+                Value::Integer(*key_type as i128),
+            );
+            pub_key_cred_params_val.insert(
+                Value::Text("type".to_string()),
+                Value::Text("public-key".to_string()),
+            );
+            Value::Map(pub_key_cred_params_val)
+        })
+        .collect();
+
+    let pub_key_cred_params = Value::Array(pub_key_cred_params_vec);
 
     // 0x05 : excludeList
     let exclude_list = Value::Array(

--- a/src/fidokey/make_credential/make_credential_params.rs
+++ b/src/fidokey/make_credential/make_credential_params.rs
@@ -93,7 +93,7 @@ pub struct MakeCredentialArgs<'a> {
     pub rpid: String,
     pub challenge: Vec<u8>,
     pub pin: Option<&'a str>,
-    pub key_type: Option<CredentialSupportedKeyType>,
+    pub key_type: Vec<CredentialSupportedKeyType>,
     pub uv: Option<bool>,
     pub exclude_list: Vec<Vec<u8>>,
     pub user_entity: Option<PublicKeyCredentialUserEntity>,
@@ -111,7 +111,7 @@ pub struct MakeCredentialArgsBuilder<'a> {
     rpid: String,
     challenge: Vec<u8>,
     pin: Option<&'a str>,
-    key_type: Option<CredentialSupportedKeyType>,
+    key_type: Vec<CredentialSupportedKeyType>,
     uv: Option<bool>,
     exclude_list: Vec<Vec<u8>>,
     user_entity: Option<PublicKeyCredentialUserEntity>,
@@ -153,7 +153,7 @@ impl<'a> MakeCredentialArgsBuilder<'a> {
         mut self,
         key_type: CredentialSupportedKeyType,
     ) -> MakeCredentialArgsBuilder<'a> {
-        self.key_type = Some(key_type);
+        self.key_type.push(key_type);
         self
     }
 

--- a/src/fidokey/make_credential/mod.rs
+++ b/src/fidokey/make_credential/mod.rs
@@ -37,9 +37,7 @@ impl FidoKeyHid {
             params.option_uv = args.uv;
 
             params.exclude_list = args.exclude_list.to_vec();
-            params.key_type = args
-                .key_type
-                .unwrap_or(CredentialSupportedKeyType::Ecdsa256);
+            params.key_type = args.key_type.clone();
 
             if let Some(rkp) = &args.user_entity {
                 params.user_name = rkp.name.to_string();


### PR DESCRIPTION
CTAP2 allows us to specify a list of acceptable key types during credential creation. This is helpful when supporting devices like Yubikey < 5.2. Normally we'd prefer ED25519, but these older devices don't support it so we want to specify `ED25519` then `ECDSA256` as a fallback.

This change allows `MakeCredentialArgsBuilder::key_type` to be repeatedly invoked to specify multiple key types.

Not sure what the best practice is for testing. 