### PR TITLE
Fix unwrap panic when using hmac secret with multiple credentials

### DIFF
--- a/src/fidokey/get_assertion/get_assertion_response.rs
+++ b/src/fidokey/get_assertion/get_assertion_response.rs
@@ -51,6 +51,10 @@ fn parse_cbor_authdata(
             if util_ciborium::is_text(key) {
                 let member = util_ciborium::cbor_value_to_str(key)?;
                 if member == Extension::HmacSecret(None).to_string() {
+                    if shared_secret.is_none() {
+                        continue
+                    }
+
                     // 12.5. HMAC Secret Extension (hmac-secret)
                     // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-hmac-secret-extension
 


### PR DESCRIPTION
Currently, when not filtering credential IDs and when multiple credentials are available, assertions panic since the `shared_secret` is `None`, and is being unwrapped. This fixes the panic by simply skipping parsing of the hmac secret response.

(I did not investigate further, whether there is a better solution available.)