### PR TITLE
add GetAssertionArgsBuilder::without_up() method

### DIFF
--- a/src/fidokey/get_assertion/get_assertion_params.rs
+++ b/src/fidokey/get_assertion/get_assertion_params.rs
@@ -80,6 +80,7 @@ pub struct GetAssertionArgs<'a> {
     pub challenge: Vec<u8>,
     pub pin: Option<&'a str>,
     pub credential_ids: Vec<Vec<u8>>,
+    pub up: bool,
     pub uv: Option<bool>,
     pub extensions: Option<Vec<Extension>>,
 }
@@ -95,12 +96,14 @@ pub struct GetAssertionArgsBuilder<'a> {
     challenge: Vec<u8>,
     pin: Option<&'a str>,
     credential_ids: Vec<Vec<u8>>,
+    up: bool,
     uv: Option<bool>,
     extensions: Option<Vec<Extension>>,
 }
 impl<'a> GetAssertionArgsBuilder<'a> {
     pub fn new(rpid: &str, challenge: &[u8]) -> GetAssertionArgsBuilder<'a> {
         GetAssertionArgsBuilder::<'_> {
+            up: true,
             uv: Some(true),
             rpid: String::from(rpid),
             challenge: challenge.to_vec(),
@@ -118,6 +121,11 @@ impl<'a> GetAssertionArgsBuilder<'a> {
     pub fn without_pin_and_uv(mut self) -> GetAssertionArgsBuilder<'a> {
         self.pin = None;
         self.uv = None;
+        self
+    }
+
+    pub fn without_up(mut self) -> GetAssertionArgsBuilder<'a> {
+        self.up = false;
         self
     }
 
@@ -142,6 +150,7 @@ impl<'a> GetAssertionArgsBuilder<'a> {
             challenge: self.challenge,
             pin: self.pin,
             credential_ids: self.credential_ids,
+            up: self.up,
             uv: self.uv,
             extensions: self.extensions,
         }

--- a/src/fidokey/get_assertion/mod.rs
+++ b/src/fidokey/get_assertion/mod.rs
@@ -32,7 +32,7 @@ impl FidoKeyHid {
             args.challenge.to_vec(),
             credential_ids.to_vec(),
         );
-        params.option_up = true;
+        params.option_up = args.up;
         params.option_uv = args.uv;
 
         // create pin auth


### PR DESCRIPTION
Some work flows like to do what the CTAP standard refers to as a "pre-flight" check:

>  pre-flight
> In order to determine whether authenticatorMakeCredential’s
   excludeList or authenticatorGetAssertion’s allowList contain
   credential IDs that are already present on an authenticator,
   a platform typically invokes authenticatorGetAssertion with
   the "up" option key set to false and optionally
   pinUvAuthParam one or more times. If a credential is found an
   assertion is returned. If a valid pinUvAuthParam was also
   provided, the response will contain "up"=0 and "uv"=1 within
   the "flags bits"

This PR adds a ::without_up() method to the
get_assertion_params::GetAssertionArgsBuilder struct to allow for this usage.  Example code making use of this, lifted from working code making use of this patch is:

    fn probe_device(dev: &FidoKeyHid, rp: &str, cred: &[u8]) -> bool {
        let req = FidoKeyGetAssertionArgsBuilder::new(rp, &fidokey_verifier::create_challenge())
            .credential_id(cred)
            .without_pin_and_uv()
            .without_up()
            .build();
        dev.get_assertion_with_args(&req).is_ok()
    }

Further background:
=================
In the context in which the above fn is being used, the application knows several candidate credentials for the user, each associated with a different authenticator token (i.e., a primary and a few backups).  The goal is to figure out which (if any) credentials are usable at the current sitting, and *then* ask the user to interact with the token for a known good device/cred pair in order to obtain a valid assertion. Without the .without_up() the user is bothered to prove presence to the active authenticator for each candidate credential until a match is finally found; using .without_up() these probes happen without user intervention.