### PR TITLE
Fix default handling, and associated DRY clean-up for GetAssertionArgs*

### DIFF
--- a/src/fidokey/get_assertion/get_assertion_params.rs
+++ b/src/fidokey/get_assertion/get_assertion_params.rs
@@ -84,75 +84,73 @@ pub struct GetAssertionArgs<'a> {
     pub uv: Option<bool>,
     pub extensions: Option<Vec<Extension>>,
 }
+impl<'a> Default for GetAssertionArgs<'a> {
+    fn default() -> Self {
+        Self {
+            rpid: String::new(),
+            challenge: Vec::new(),
+            pin: None,
+            credential_ids: Vec::new(),
+            up: true,
+            uv: Some(true),
+            extensions: None,
+        }
+    }
+}
 impl<'a> GetAssertionArgs<'a> {
     pub fn builder() -> GetAssertionArgsBuilder<'a> {
-        GetAssertionArgsBuilder::default()
+        GetAssertionArgsBuilder::new("", b"")
     }
 }
 
 #[derive(Default)]
 pub struct GetAssertionArgsBuilder<'a> {
-    rpid: String,
-    challenge: Vec<u8>,
-    pin: Option<&'a str>,
-    credential_ids: Vec<Vec<u8>>,
-    up: bool,
-    uv: Option<bool>,
-    extensions: Option<Vec<Extension>>,
+    inner: GetAssertionArgs<'a>,
 }
 impl<'a> GetAssertionArgsBuilder<'a> {
     pub fn new(rpid: &str, challenge: &[u8]) -> GetAssertionArgsBuilder<'a> {
-        GetAssertionArgsBuilder::<'_> {
-            up: true,
-            uv: Some(true),
+        let inner = GetAssertionArgs {
             rpid: String::from(rpid),
             challenge: challenge.to_vec(),
             ..Default::default()
-        }
+        };
+        GetAssertionArgsBuilder { inner }
     }
 
     pub fn pin(mut self, pin: &'a str) -> GetAssertionArgsBuilder<'a> {
-        self.pin = Some(pin);
-        //self.uv = Some(false);
-        self.uv = None;
+        self.inner.pin = Some(pin);
+        //self.inner.uv = Some(false);
+        self.inner.uv = None;
         self
     }
 
     pub fn without_pin_and_uv(mut self) -> GetAssertionArgsBuilder<'a> {
-        self.pin = None;
-        self.uv = None;
+        self.inner.pin = None;
+        self.inner.uv = None;
         self
     }
 
     pub fn without_up(mut self) -> GetAssertionArgsBuilder<'a> {
-        self.up = false;
+        self.inner.up = false;
         self
     }
 
     pub fn extensions(mut self, extensions: &[Extension]) -> GetAssertionArgsBuilder<'a> {
-        self.extensions = Some(extensions.to_vec());
+        self.inner.extensions = Some(extensions.to_vec());
         self
     }
 
     pub fn credential_id(mut self, credential_id: &[u8]) -> GetAssertionArgsBuilder<'a> {
-        self.credential_ids.clear();
+        self.inner.credential_ids.clear();
         self.add_credential_id(credential_id)
     }
 
     pub fn add_credential_id(mut self, credential_id: &[u8]) -> GetAssertionArgsBuilder<'a> {
-        self.credential_ids.push(credential_id.to_vec());
+        self.inner.credential_ids.push(credential_id.to_vec());
         self
     }
 
     pub fn build(self) -> GetAssertionArgs<'a> {
-        GetAssertionArgs {
-            rpid: self.rpid,
-            challenge: self.challenge,
-            pin: self.pin,
-            credential_ids: self.credential_ids,
-            up: self.up,
-            uv: self.uv,
-            extensions: self.extensions,
-        }
+        self.inner
     }
 }


### PR DESCRIPTION
This is a follow-up to PR#117, based on the code review comment generated by Claude Code.  Claude is correct that there are ways of instantiating GetAssertionArgs and GetAssertionArgsBuilder such that the defaulted values of .up (and, not mentioned in the review, .uv) are not as-desired.

In PR#117 I was solely concerned with adding the .without_up() method to GetAssertionArgsBuilder, with minimum fuss.  I mimicked the handling of the .uv entity, and failed to considered paths other than GetAssertionArgsBuilder::new() for creating the relevant structures.

For this commit I took a step back and considered the whole of fidokey/get_assertion/get_assertion_params.rs.  There was duplication of the contents of the GetAssertionArgs and GetAssertionArgs builder structs, and there were code paths which allowed the .up and .uv members to be defaulted to false/None, despite the apparent intent in GetAssertionArgsBuilder that these should default to true/Some(true).

To clean this situation up, I did the following:
  * added an impl Default to GetAssertionArgs
  * made the GetAssertionArgsBuilder struct simply contain an inner GetAssertionArgs struct (and updated references to the now-inner fields)
  * made GetAssertionArgs::builder() just be a wrapper around GetAssertionArgsBuilder::new()