### PR TITLE
Reuse pinUvAuthToken across credential management enumeration (fixes #115)

### DIFF
--- a/src/fidokey/credential_management/credential_management_command.rs
+++ b/src/fidokey/credential_management/credential_management_command.rs
@@ -37,7 +37,7 @@ impl SubCommandBase for SubCommand {
 }
 
 pub fn create_payload(
-    pin_token: Option<pintoken::PinToken>,
+    pin_token: Option<&pintoken::PinToken>,
     sub_command: SubCommand,
     use_pre_credential_management: bool,
     pin_protocol_version: u8,

--- a/src/fidokey/credential_management/mod.rs
+++ b/src/fidokey/credential_management/mod.rs
@@ -3,7 +3,8 @@ pub mod credential_management_params;
 pub mod credential_management_response;
 use super::{pin::Permission::CredentialManagement, FidoKeyHid};
 use crate::{
-    ctaphid, public_key_credential_descriptor::PublicKeyCredentialDescriptor,
+    ctaphid, pintoken::PinToken,
+    public_key_credential_descriptor::PublicKeyCredentialDescriptor,
     public_key_credential_user_entity::PublicKeyCredentialUserEntity, util,
 };
 use anyhow::Result;
@@ -18,23 +19,30 @@ impl FidoKeyHid {
         &self,
         pin: Option<&str>,
     ) -> Result<CredentialsCount> {
-        let meta = self.credential_management(pin, SubCommand::GetCredsMetadata)?;
+        let pin_token = self.acquire_cm_token(pin)?;
+        let meta = self.credential_management(pin_token.as_ref(), SubCommand::GetCredsMetadata)?;
         Ok(CredentialsCount::new(&meta))
     }
 
     /// CredentialManagement - enumerateRPsBegin & enumerateRPsNext (CTAP 2.1-PRE)
+    ///
+    /// The same pinUvAuthToken is used for `EnumerateRPsBegin` and every
+    /// subsequent `EnumerateRPsGetNextRp` call. Per CTAP 2.1 §6.8 an
+    /// authenticator MUST discard the stateful enumeration if the
+    /// pinUvAuthToken that authenticated the initializing command expires —
+    /// and issuing a fresh pinUvAuthToken for each iteration expires the
+    /// prior one, causing `CTAP2_ERR_NOT_ALLOWED` on the continuation.
     pub fn credential_management_enumerate_rps(&self, pin: Option<&str>) -> Result<Vec<Rp>> {
+        let pin_token = self.acquire_cm_token(pin)?;
         let mut datas: Vec<Rp> = Vec::new();
-        let data = self.credential_management(pin, SubCommand::EnumerateRPsBegin)?;
+        let data = self.credential_management(pin_token.as_ref(), SubCommand::EnumerateRPsBegin)?;
 
         if data.total_rps > 0 {
             datas.push(Rp::new(&data));
             let roop_n = data.total_rps - 1;
             for _ in 0..roop_n {
-                // TODO : It results in an error with the latest YubiKey. The following updates are required:
-                // - Set cfg.use_pre_credential_management = false.
-                // - Ensure that the pinUvAuthToken obtained via EnumerateRPsBegin is used in EnumerateRPsGetNextRp.                
-                let data = self.credential_management(pin, SubCommand::EnumerateRPsGetNextRp)?;
+                let data = self
+                    .credential_management(pin_token.as_ref(), SubCommand::EnumerateRPsGetNextRp)?;
                 datas.push(Rp::new(&data));
             }
         }
@@ -42,15 +50,19 @@ impl FidoKeyHid {
     }
 
     /// CredentialManagement - enumerateCredentialsBegin & enumerateCredentialsNext (CTAP 2.1-PRE)
+    ///
+    /// See `credential_management_enumerate_rps` for why the same
+    /// pinUvAuthToken is reused across the stateful iteration.
     pub fn credential_management_enumerate_credentials(
         &self,
         pin: Option<&str>,
         rpid_hash: &[u8],
     ) -> Result<Vec<credential_management_params::Credential>> {
+        let pin_token = self.acquire_cm_token(pin)?;
         let mut datas: Vec<Credential> = Vec::new();
 
         let data = self.credential_management(
-            pin,
+            pin_token.as_ref(),
             SubCommand::EnumerateCredentialsBegin(rpid_hash.to_vec()),
         )?;
 
@@ -59,7 +71,7 @@ impl FidoKeyHid {
             let roop_n = data.total_credentials - 1;
             for _ in 0..roop_n {
                 let data = self.credential_management(
-                    pin,
+                    pin_token.as_ref(),
                     SubCommand::EnumerateCredentialsGetNextCredential(rpid_hash.to_vec()),
                 )?;
                 datas.push(Credential::new(&data));
@@ -74,7 +86,8 @@ impl FidoKeyHid {
         pin: Option<&str>,
         pkcd: PublicKeyCredentialDescriptor,
     ) -> Result<()> {
-        self.credential_management(pin, SubCommand::DeleteCredential(pkcd))?;
+        let pin_token = self.acquire_cm_token(pin)?;
+        self.credential_management(pin_token.as_ref(), SubCommand::DeleteCredential(pkcd))?;
         Ok(())
     }
 
@@ -85,28 +98,33 @@ impl FidoKeyHid {
         pkcd: PublicKeyCredentialDescriptor,
         pkcue: PublicKeyCredentialUserEntity,
     ) -> Result<()> {
-        self.credential_management(pin, SubCommand::UpdateUserInformation(pkcd, pkcue))?;
+        let pin_token = self.acquire_cm_token(pin)?;
+        self.credential_management(
+            pin_token.as_ref(),
+            SubCommand::UpdateUserInformation(pkcd, pkcue),
+        )?;
         Ok(())
+    }
+
+    fn acquire_cm_token(&self, pin: Option<&str>) -> Result<Option<PinToken>> {
+        match pin {
+            Some(pin) => {
+                let token = if self.use_pre_credential_management {
+                    self.get_pin_token(pin)?
+                } else {
+                    self.get_pinuv_auth_token_with_permission(pin, CredentialManagement)?
+                };
+                Ok(Some(token))
+            }
+            None => Ok(None),
+        }
     }
 
     fn credential_management(
         &self,
-        pin: Option<&str>,
+        pin_token: Option<&PinToken>,
         sub_command: SubCommand,
     ) -> Result<CredentialManagementData> {
-        // pin token
-        let pin_token = {
-            if let Some(pin) = pin {
-                if self.use_pre_credential_management {
-                    Some(self.get_pin_token(pin)?)
-                } else {
-                    Some(self.get_pinuv_auth_token_with_permission(pin, CredentialManagement)?)
-                }
-            } else {
-                None
-            }
-        };
-
         let send_payload = credential_management_command::create_payload(
             pin_token,
             sub_command,


### PR DESCRIPTION
## Summary

Fixes `credential_management_enumerate_rps` / `credential_management_enumerate_credentials` failing with `CTAP2_ERR_NOT_ALLOWED (0x30)` on the `GetNextRp` / `GetNextCredential` continuation. Reported in #115 against YubiKey firmware 5.7.4 and also observed downstream in [`fido-ssh-agent`](https://github.com/oknyshuk/fido-ssh-agent) against other keys.

## Root cause

`credential_management()` acquires a fresh `pinUvAuthToken` on every subcommand call. `Begin` subcommands initialize authenticator-side enumeration state; the `GetNext*` subcommands read from that state.

Per CTAP 2.1 §6.8 ([spec](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html)):

> An authenticator MUST discard the state for a stateful command if the pinUvAuthToken that authenticated the state initializing command expires, since the stateful commands do not themselves always verify a pinUvAuthToken.

Issuing a fresh `pinUvAuthToken` for the continuation invalidates the one that authenticated `Begin`, so the authenticator drops the enumeration state and rejects `GetNext*` with `CTAP2_ERR_NOT_ALLOWED`. The bug only manifests when there are ≥2 RPs / credentials on the device, which is why it goes unnoticed on keys holding a single discoverable credential.

This matches the TODO previously noted inline at `src/fidokey/credential_management/mod.rs`:

```
// TODO : It results in an error with the latest YubiKey. The following updates are required:
// - Set cfg.use_pre_credential_management = false.
// - Ensure that the pinUvAuthToken obtained via EnumerateRPsBegin is used in EnumerateRPsGetNextRp.
```

## Change

- Each public `credential_management_*` wrapper acquires the `pinUvAuthToken` once via a new private helper `acquire_cm_token()` and passes it by reference into `credential_management()` for every subcommand in the iteration.
- `create_payload()` now takes `Option<&PinToken>` so the caller retains ownership across the loop. This function is `pub` but lives under `src/fidokey/credential_management/`, which is not re-exported at the crate root, so external callers are not affected.
- No public API surface changes. `use_pre_credential_management` is not touched — the existing test `test_credential_management_enumerate_rps` (tests/tests.rs) already pins it to `false`, so I left default selection alone as a separate concern.

## Testing

- `cargo build`, `cargo build --examples`, and `cargo clippy --lib -- -D warnings` pass.
- I do not have a YubiKey 5.7.x with ≥2 discoverable-credential RPs available to reproduce #115 end-to-end. The fix is derived from the spec text quoted above and from the inline TODO. Anyone hitting #115 can validate with `cargo run --example ctapcli cred -l` against this branch.

Refs: #115