### PR TITLE
ctaphid: gate error prints behind `enable_log`

### DIFF
--- a/src/ctaphid.rs
+++ b/src/ctaphid.rs
@@ -380,10 +380,14 @@ fn ctaphid_cbormsg(device: &FidoKeyHid, command: u8, payload: &[u8]) -> Result<V
             }
             thread::sleep(time::Duration::from_millis(100));
         } else if st.0 == CTAPHID_ERROR {
-            println!("CTAPHID_ERROR Error code = 0x{:02x}", st.2);
+            if device.enable_log {
+                println!("CTAPHID_ERROR Error code = 0x{:02x}", st.2);
+            }
             break;
         } else {
-            println!("err");
+            if device.enable_log {
+                println!("err");
+            }
             break;
         }
     }


### PR DESCRIPTION
Other prints in the response loop of `ctaphid_cbormsg` already check `device.enable_log`, but the `CTAPHID_ERROR` and unknown-status branches printed unconditionally.