### PR TITLE
Support PIN auth protocol 2 (32-byte HMAC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctap-hid-fido2"
-version = "3.5.11"
+version = "3.5.12"
 authors = ["gebo <35388172+gebogebogebo@users.noreply.github.com>"]
 edition = "2021"
 rust-version = "1.88"
@@ -20,9 +20,9 @@ aws-lc-rs = ["dep:aws-lc-rs"]
 fips = ["aws-lc-rs", "aws-lc-rs/fips"]
 
 [dependencies]
-aes = "0.9.0"
-anyhow = "1.0.102"
-aws-lc-rs = { version = "1.17.0", optional = true }
+aes = "0.9.1"
+anyhow = "1.0.103"
+aws-lc-rs = { version = "1.17.3", optional = true }
 base64 = "0.22.1"
 byteorder = "1.5.0"
 cbc = "0.2.1"
@@ -42,10 +42,10 @@ default-features = false
 features=["linux-static-hidraw"]
 
 [dev-dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
-env_logger = "0.11.10"
-log = "0.4.29"
-rpassword = "7.5.3"
+clap = { version = "4.6.2", features = ["derive"] }
+env_logger = "0.11.11"
+log = "0.4.33"
+rpassword = "7.5.4"
 arboard = "3.6.1"
 colored = "3.1.1"
 

--- a/README_Version.md
+++ b/README_Version.md
@@ -1,4 +1,14 @@
 ## Version
+### Ver 3.5.12
+- Addressed [issue #126](https://github.com/gebogebogebo/ctap-hid-fido2/issues/126).
+- Addressed [pull request #133](https://github.com/gebogebogebo/ctap-hid-fido2/pull/133).
+  - Fixed `non_discoverable_credentials` (make_credential / get_assertion) failing under [PIN/UV Auth Protocol Two](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2): `pinUvAuthParam` was always truncated to 16 bytes regardless of the negotiated protocol; Protocol Two now correctly returns the full 32-byte HMAC-SHA-256 output.
+  - Fixed the same truncation bug in bio enrollment, credential management, large blobs, and authenticator config commands.
+  - Fixed the `hmac-secret` extension to be PIN/UV Auth Protocol-aware (it previously always used Protocol One's shared-secret derivation/truncation regardless of the negotiated protocol).
+  - Centralized PIN/UV Auth Protocol version validation and shared-secret handling into a single module, removing duplicated per-protocol branching across the PIN, bio enrollment, credential management, large blobs, and authenticator config code paths.
+  - example: [test-with-pin-non-rk](examples/test-with-pin-non-rk/main.rs) / [test-with-pin-rk](examples/test-with-pin-rk/main.rs) now exercise both PIN/UV Auth Protocol One and Two.
+- Dependency Updates.
+
 ### Ver 3.5.11
 - Addressed [issue #127](https://github.com/gebogebogebo/ctap-hid-fido2/issues/127).
 - Addressed [pull request #128](https://github.com/gebogebogebo/ctap-hid-fido2/pull/128).

--- a/examples/test-with-pin-non-rk/main.rs
+++ b/examples/test-with-pin-non-rk/main.rs
@@ -118,9 +118,26 @@ fn main() -> Result<()> {
 
     let mut device = FidoKeyHidFactory::create(&cfg)?;
 
-    builder_pattern_sample(&mut device, rpid, pin)?;
+    for pin_protocol_version in [1u8, 2u8] {
+        print_section(&format!(
+            "===== PIN/UV Auth Protocol {} =====",
+            pin_protocol_version
+        ));
 
-    legacy_pattern_sample(&device, rpid, pin)?;
+        if pin_protocol_version == 2 {
+            if !device.set_pin_uv_auth_protocol_two()? {
+                print_info("pin_protocol_two not supported, skipping.");
+                println!();
+                continue;
+            }
+        } else {
+            device.pin_protocol_version = 1;
+        }
+
+        builder_pattern_sample(&mut device, rpid, pin)?;
+
+        legacy_pattern_sample(&device, rpid, pin)?;
+    }
 
     print_test_summary();
     print_section("----- test-with-pin-non-rk end -----");
@@ -142,10 +159,6 @@ fn builder_pattern_sample(device: &mut FidoKeyHid, rpid: &str, pin: &str) -> Res
     }
 
     non_discoverable_credentials(device, rpid, pin).unwrap_or_else(|err| {
-        print_error_with_count(&format!("Error => {}\n", err), true);
-    });
-
-    non_discoverable_credentials_pin_protocol_two(device, rpid, pin).unwrap_or_else(|err| {
         print_error_with_count(&format!("Error => {}\n", err), true);
     });
 
@@ -258,81 +271,6 @@ fn non_discoverable_credentials(device: &FidoKeyHid, rpid: &str, pin: &str) -> R
 
     println!();
     Ok(())
-}
-
-fn non_discoverable_credentials_pin_protocol_two(
-    device: &mut FidoKeyHid,
-    rpid: &str,
-    pin: &str,
-) -> Result<()> {
-    print_section("----- non_discoverable_credentials with pin_protocol_two -----");
-
-    if !device.set_pin_uv_auth_protocol_two()? {
-        print_info("pin_protocol_two not supported, skipping test.");
-        println!();
-        return Ok(());
-    }
-
-    let body_result = (|| -> Result<()> {
-        print_step("- Register");
-        let challenge = verifier::create_challenge();
-
-        let make_credential_args = MakeCredentialArgsBuilder::new(rpid, &challenge)
-            .pin(pin)
-            .build();
-
-        let attestation = device.make_credential_with_args(&make_credential_args)?;
-        print_success("-- Register Success");
-        debug!("Attestation");
-        debug!("{}", attestation);
-
-        print_step("-- Verify Attestation");
-        let verify_result = verifier::verify_attestation(rpid, &challenge, &attestation);
-        if verify_result.is_success {
-            print_success("-- Verify Attestation Success");
-        } else {
-            print_error("-- ! Verify Attestation Failed");
-        }
-
-        print_step("- Authenticate");
-
-        // pre-flight
-        if !probe_device(device, rpid, &verify_result.credential_id) {
-            print_error("-- ! probe_device failed (silent getAssertion pre-flight rejected)");
-        }
-
-        let challenge = verifier::create_challenge();
-
-        let get_assertion_args = GetAssertionArgsBuilder::new(rpid, &challenge)
-            .pin(pin)
-            .credential_id(&verify_result.credential_id)
-            .build();
-
-        let assertions = device.get_assertion_with_args(&get_assertion_args)?;
-        print_success("-- Authenticate Success");
-        debug!("Assertion");
-        debug!("{}", assertions[0]);
-
-        print_step("-- Verify Assertion");
-        let is_success = verifier::verify_assertion(
-            rpid,
-            &verify_result.credential_public_key,
-            &challenge,
-            &assertions[0],
-        );
-        if is_success {
-            print_success("-- Verify Assertion Success");
-        } else {
-            print_error("-- ! Verify Assertion Failed");
-        }
-
-        Ok(())
-    })();
-
-    device.pin_protocol_version = 1;
-
-    println!();
-    body_result
 }
 
 fn with_uv(device: &FidoKeyHid, rpid: &str) -> Result<()> {

--- a/examples/test-with-pin-rk/main.rs
+++ b/examples/test-with-pin-rk/main.rs
@@ -118,22 +118,39 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let device = FidoKeyHidFactory::create(&cfg)?;
+    let mut device = FidoKeyHidFactory::create(&cfg)?;
 
-    //
-    // Builder Pattern Sample
-    //
-    discoverable_credentials(&device, "test-rk.com", pin)
-        .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+    for pin_protocol_version in [1u8, 2u8] {
+        print_section(&format!(
+            "===== PIN/UV Auth Protocol {} =====",
+            pin_protocol_version
+        ));
 
-    with_cred_blob_ex(&device, "test-rk-2.com", pin)
-        .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+        if pin_protocol_version == 2 {
+            if !device.set_pin_uv_auth_protocol_two()? {
+                print_info("pin_protocol_two not supported, skipping.");
+                println!();
+                continue;
+            }
+        } else {
+            device.pin_protocol_version = 1;
+        }
 
-    //
-    // Legacy Pattern Sample
-    //
-    legacy_discoverable_credentials(&device, "test-rk-legacy.com", pin)
-        .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+        //
+        // Builder Pattern Sample
+        //
+        discoverable_credentials(&device, "test-rk.com", pin)
+            .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+
+        with_cred_blob_ex(&device, "test-rk-2.com", pin)
+            .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+
+        //
+        // Legacy Pattern Sample
+        //
+        legacy_discoverable_credentials(&device, "test-rk-legacy.com", pin)
+            .unwrap_or_else(|err| print_error_with_count(&format!("Error => {}\n", err), true));
+    }
 
     print_test_summary();
     print_section("----- test-with-pin-rk end -----");

--- a/src/encrypt/enc_hmac_sha_256.rs
+++ b/src/encrypt/enc_hmac_sha_256.rs
@@ -1,25 +1,7 @@
 use crate::crypto::hmac;
-use anyhow::{anyhow, Result};
 
 pub fn authenticate(key: &[u8], message: &[u8]) -> Vec<u8> {
     let hmac_key = hmac::Key::new(hmac::HMAC_SHA256, key);
     let tag = hmac::sign(&hmac_key, message);
     tag.as_ref().to_vec()
-}
-
-/// Compute a pinUvAuthParam for the negotiated PIN/UV Auth Protocol version.
-///
-/// - Protocol One (6.5.7. authenticate): LEFT(HMAC-SHA-256(key, message), 16)
-/// - Protocol Two (6.5.8. authenticate): HMAC-SHA-256(key, message) (32 bytes, untruncated)
-pub fn compute_pin_uv_auth_param(
-    key: &[u8],
-    message: &[u8],
-    pin_protocol_version: u8,
-) -> Result<Vec<u8>> {
-    let sig = authenticate(key, message);
-    match pin_protocol_version {
-        1 => Ok(sig[0..16].to_vec()),
-        2 => Ok(sig),
-        _ => Err(anyhow!("unknown pin_protocol_version")),
-    }
 }

--- a/src/encrypt/enc_hmac_sha_256.rs
+++ b/src/encrypt/enc_hmac_sha_256.rs
@@ -1,7 +1,25 @@
 use crate::crypto::hmac;
+use anyhow::{anyhow, Result};
 
 pub fn authenticate(key: &[u8], message: &[u8]) -> Vec<u8> {
     let hmac_key = hmac::Key::new(hmac::HMAC_SHA256, key);
     let tag = hmac::sign(&hmac_key, message);
     tag.as_ref().to_vec()
+}
+
+/// Compute a pinUvAuthParam for the negotiated PIN/UV Auth Protocol version.
+///
+/// - Protocol One (6.5.7. authenticate): LEFT(HMAC-SHA-256(key, message), 16)
+/// - Protocol Two (6.5.8. authenticate): HMAC-SHA-256(key, message) (32 bytes, untruncated)
+pub fn compute_pin_uv_auth_param(
+    key: &[u8],
+    message: &[u8],
+    pin_protocol_version: u8,
+) -> Result<Vec<u8>> {
+    let sig = authenticate(key, message);
+    match pin_protocol_version {
+        1 => Ok(sig[0..16].to_vec()),
+        2 => Ok(sig),
+        _ => Err(anyhow!("unknown pin_protocol_version")),
+    }
 }

--- a/src/encrypt/shared_secret.rs
+++ b/src/encrypt/shared_secret.rs
@@ -36,34 +36,28 @@ impl SharedSecret {
         Ok(res)
     }
 
-    pub fn encrypt_pin(&self, pin: &str) -> Result<[u8; 16]> {
-        self.encrypt(pin.as_bytes())
-    }
-
-    pub fn encrypt(&self, data: &[u8]) -> Result<[u8; 16]> {
-        let hash = digest::digest(&digest::SHA256, data);
-        let message = &hash.as_ref()[0..16];
-        let enc = enc_aes256_cbc::encrypt_message(&self.secret, message);
-        let mut out_bytes = [0; 16];
-        out_bytes.copy_from_slice(&enc[0..16]);
-        Ok(out_bytes)
+    pub fn encrypt_pin(&self, pin: &str) -> Result<Vec<u8>> {
+        // pinHashEnc: encrypt(shared secret, LEFT(SHA-256(pin), 16))
+        let hash = digest::digest(&digest::SHA256, pin.as_bytes());
+        let dem_plaintext = &hash.as_ref()[0..16];
+        Ok(self.encrypt(dem_plaintext))
     }
 
     pub fn decrypt_token(&self, data: &[u8]) -> Result<PinToken> {
-        let dec = enc_aes256_cbc::decrypt_message(&self.secret, data);
+        let dec = self.decrypt(data);
         let pin_token = PinToken::new(&dec);
         Ok(pin_token)
     }
 
     /// 6.5.6. PIN/UV Auth Protocol One: encrypt(key, demPlaintext) → ciphertext
     /// AES-256-CBC(key, IV=0, demPlaintext), no padding.
-    pub fn encrypt_raw(&self, dem_plaintext: &[u8]) -> Vec<u8> {
+    pub fn encrypt(&self, dem_plaintext: &[u8]) -> Vec<u8> {
         enc_aes256_cbc::encrypt_message(&self.secret, dem_plaintext)
     }
 
     /// 6.5.6. PIN/UV Auth Protocol One: decrypt(key, demCiphertext) → plaintext
     /// AES-256-CBC(key, IV=0, demCiphertext), no padding.
-    pub fn decrypt_raw(&self, dem_cipher_text: &[u8]) -> Vec<u8> {
+    pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Vec<u8> {
         enc_aes256_cbc::decrypt_message(&self.secret, dem_cipher_text)
     }
 }

--- a/src/encrypt/shared_secret.rs
+++ b/src/encrypt/shared_secret.rs
@@ -49,7 +49,7 @@ impl SharedSecret {
         Ok(out_bytes)
     }
 
-    pub fn decrypt_token(&self, data: &mut [u8]) -> Result<PinToken> {
+    pub fn decrypt_token(&self, data: &[u8]) -> Result<PinToken> {
         let dec = enc_aes256_cbc::decrypt_message(&self.secret, data);
         let pin_token = PinToken::new(&dec);
         Ok(pin_token)

--- a/src/encrypt/shared_secret.rs
+++ b/src/encrypt/shared_secret.rs
@@ -54,4 +54,16 @@ impl SharedSecret {
         let pin_token = PinToken::new(&dec);
         Ok(pin_token)
     }
+
+    /// 6.5.6. PIN/UV Auth Protocol One: encrypt(key, demPlaintext) → ciphertext
+    /// AES-256-CBC(key, IV=0, demPlaintext), no padding.
+    pub fn encrypt_raw(&self, dem_plaintext: &[u8]) -> Vec<u8> {
+        enc_aes256_cbc::encrypt_message(&self.secret, dem_plaintext)
+    }
+
+    /// 6.5.6. PIN/UV Auth Protocol One: decrypt(key, demCiphertext) → plaintext
+    /// AES-256-CBC(key, IV=0, demCiphertext), no padding.
+    pub fn decrypt_raw(&self, dem_cipher_text: &[u8]) -> Vec<u8> {
+        enc_aes256_cbc::decrypt_message(&self.secret, dem_cipher_text)
+    }
 }

--- a/src/encrypt/shared_secret2.rs
+++ b/src/encrypt/shared_secret2.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Error, Result};
 
 use crate::crypto::{agreement, digest, hkdf, rand};
 
+#[derive(Debug, Clone)]
 pub struct SharedSecret2 {
     pub secret: [u8; 64],
     pub public_key: CoseKey,
@@ -66,16 +67,15 @@ impl SharedSecret2 {
         // Generate demPlaintext from pin
         let hash = digest::digest(&digest::SHA256, pin.as_bytes());
         let dem_plaintext = &hash.as_ref()[0..16];
+        self.encrypt(dem_plaintext)
+    }
 
-        //
-        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2
-        //
-        // 6.5.7. PIN/UV Auth Protocol Two
-        // [encrypt(key, demPlaintext) → ciphertext]
-        //
-
+    /// 6.5.7. PIN/UV Auth Protocol Two: encrypt(key, demPlaintext) → ciphertext
+    /// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2
+    ///
+    /// `demPlaintext` must be a multiple of the AES block length (16 bytes); no padding is performed.
+    pub fn encrypt(&self, dem_plaintext: &[u8]) -> Result<Vec<u8>> {
         // 1. Discard the first 32 bytes of key. (This selects the AES-key portion of the shared secret.)
-        // Get AES key from the second half of self.secret
         let aes_key = &self.secret[32..];
 
         // 2. Let iv be a 16-byte, random bytestring.
@@ -84,11 +84,10 @@ impl SharedSecret2 {
         rng.fill(&mut iv)
             .map_err(|_| anyhow!("Failed to generate random IV"))?;
 
-        // 3. Let ct be the AES-256-CBC encryption of demPlaintext using key and iv. (No padding is performed as the size of demPlaintext is required to be a multiple of the AES block length.)
+        // 3. Let ct be the AES-256-CBC encryption of demPlaintext using key and iv.
         let ciphertext = enc_aes256_cbc::encrypt_message_with_iv(aes_key, &iv, dem_plaintext);
 
         // 4. Return iv || ct.
-        // Concatenate iv and ct(ciphertext)
         let mut result = vec![];
         result.extend_from_slice(&iv);
         result.extend_from_slice(&ciphertext);
@@ -97,15 +96,13 @@ impl SharedSecret2 {
     }
 
     pub fn decrypt_token(&self, dem_cipher_text: &[u8]) -> Result<PinToken> {
-        //
-        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2
-        //
-        // 6.5.7. PIN/UV Auth Protocol Two
-        // decrypt(key, demCiphertext) → plaintext | error
-        //
+        Ok(PinToken::new(&self.decrypt(dem_cipher_text)?))
+    }
 
+    /// 6.5.7. PIN/UV Auth Protocol Two: decrypt(key, demCiphertext) → plaintext | error
+    /// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2
+    pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Result<Vec<u8>> {
         // 1. Discard the first 32 bytes of key. (This selects the AES-key portion of the shared secret.)
-        // Get AES key
         let aes_key = &self.secret[32..];
 
         // 2. If demPlaintext is less than 16 bytes in length, return an error
@@ -125,11 +122,7 @@ impl SharedSecret2 {
         }
 
         // 4. Return the AES-256-CBC decryption of ct using key and iv.
-        let buf = enc_aes256_cbc::decrypt_message_with_iv(aes_key, iv, ciphertext);
-
-        // return
-        let pin_token = PinToken::new(&buf);
-        Ok(pin_token)
+        Ok(enc_aes256_cbc::decrypt_message_with_iv(aes_key, iv, ciphertext))
     }
 }
 
@@ -192,5 +185,24 @@ mod tests {
         let data = vec![0u8; 15]; // Less than 16 bytes
         let result = ss2.decrypt_token(&data);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip_hmac_secret_salt() {
+        // hmac-secret salts are raw 32-or-64-byte plaintext, not a PIN hash,
+        // so this exercises encrypt()/decrypt() directly rather than via encrypt_pin/decrypt_token.
+        let mut secret = [0u8; 64];
+        secret[32..].copy_from_slice(&[7u8; 32]);
+        let ss2 = SharedSecret2 {
+            secret,
+            public_key: CoseKey::default(),
+        };
+
+        let salt = [9u8; 32]; // single hmac-secret salt
+        let salt_enc = ss2.encrypt(&salt).unwrap();
+        assert_eq!(salt_enc.len(), 16 + salt.len()); // iv || ciphertext
+
+        let decrypted = ss2.decrypt(&salt_enc).unwrap();
+        assert_eq!(decrypted, salt);
     }
 }

--- a/src/fidokey/authenticator_config/authenticator_config_command.rs
+++ b/src/fidokey/authenticator_config/authenticator_config_command.rs
@@ -1,6 +1,6 @@
 use super::super::sub_command_base::SubCommandBase;
 use crate::util_ciborium::ToValue;
-use crate::{ctapdef, encrypt::enc_hmac_sha_256, fidokey::common, pintoken};
+use crate::{ctapdef, fidokey::common, pin_uv_auth_protocol, pintoken};
 
 use anyhow::Result;
 use ciborium::value::Value;
@@ -117,5 +117,5 @@ fn create_pin_uv_auth_param(
     message.append(&mut vec![sub_command.id()?]);
     message.append(&mut sub_command_params_cbor.to_vec());
 
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
 }

--- a/src/fidokey/authenticator_config/authenticator_config_command.rs
+++ b/src/fidokey/authenticator_config/authenticator_config_command.rs
@@ -41,8 +41,12 @@ pub fn create_payload(
     let sub_command_params = create_sub_command_params(&sub_command)?;
 
     // 0x04: pinUvAuthParam
-    let pin_uv_auth_param =
-        create_pin_uv_auth_param(&pin_token, &sub_command, &sub_command_params.1)?;
+    let pin_uv_auth_param = create_pin_uv_auth_param(
+        &pin_token,
+        &sub_command,
+        &sub_command_params.1,
+        pin_protocol_version,
+    )?;
 
     // Create CBOR map
     let mut auth_config = vec![
@@ -103,6 +107,7 @@ fn create_pin_uv_auth_param(
     pin_token: &pintoken::PinToken,
     sub_command: &SubCommand,
     sub_command_params_cbor: &[u8],
+    pin_protocol_version: u8,
 ) -> Result<Vec<u8>> {
     // pinUvAuthParam (0x04)
     // - authenticate(pinUvAuthToken, 32×0xff || 0x0d || uint8(subCommand) || subCommandParams).
@@ -112,6 +117,5 @@ fn create_pin_uv_auth_param(
     message.append(&mut vec![sub_command.id()?]);
     message.append(&mut sub_command_params_cbor.to_vec());
 
-    let sig = enc_hmac_sha_256::authenticate(&pin_token.key, &message);
-    Ok(sig[0..16].to_vec())
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
 }

--- a/src/fidokey/bio/bio_enrollment_command.rs
+++ b/src/fidokey/bio/bio_enrollment_command.rs
@@ -66,8 +66,12 @@ pub fn create_payload(
                 map.push((0x04.to_value(), pin_protocol_version.to_value()));
 
                 // pinUvAuthParam (0x05)
-                let pin_uv_auth_param =
-                    create_pin_auth_param(pin_token, sub_cmd_id, &sub_command_params_cbor);
+                let pin_uv_auth_param = create_pin_auth_param(
+                    pin_token,
+                    sub_cmd_id,
+                    &sub_command_params_cbor,
+                    pin_protocol_version,
+                )?;
                 map.push((0x05.to_value(), pin_uv_auth_param.to_value()));
             }
         }
@@ -123,12 +127,12 @@ fn create_pin_auth_param(
     pin_token: &PinToken,
     sub_cmd_id: u8,
     sub_command_params_cbor: &[u8],
-) -> Vec<u8> {
+    pin_protocol_version: u8,
+) -> Result<Vec<u8>> {
     let mut message = vec![0x01_u8]; // fingerprint modality
     message.push(sub_cmd_id);
     message.extend_from_slice(sub_command_params_cbor);
-    let sig = enc_hmac_sha_256::authenticate(&pin_token.key, &message);
-    sig[0..16].to_vec()
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
 }
 
 /// Create template info parameter

--- a/src/fidokey/bio/bio_enrollment_command.rs
+++ b/src/fidokey/bio/bio_enrollment_command.rs
@@ -1,7 +1,7 @@
 use super::super::sub_command_base::SubCommandBase;
 use super::bio_enrollment_params::TemplateInfo;
 use crate::util_ciborium::ToValue;
-use crate::{ctapdef, encrypt::enc_hmac_sha_256, fidokey::common, pintoken::PinToken};
+use crate::{ctapdef, fidokey::common, pin_uv_auth_protocol, pintoken::PinToken};
 use anyhow::Result;
 use ciborium::value::Value;
 use strum_macros::EnumProperty;
@@ -132,7 +132,7 @@ fn create_pin_auth_param(
     let mut message = vec![0x01_u8]; // fingerprint modality
     message.push(sub_cmd_id);
     message.extend_from_slice(sub_command_params_cbor);
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&pin_token.key, &message, pin_protocol_version)
 }
 
 /// Create template info parameter

--- a/src/fidokey/credential_management/credential_management_command.rs
+++ b/src/fidokey/credential_management/credential_management_command.rs
@@ -2,7 +2,7 @@ use super::super::sub_command_base::SubCommandBase;
 use crate::public_key_credential_descriptor::PublicKeyCredentialDescriptor;
 use crate::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
 use crate::util_ciborium::ToValue;
-use crate::{ctapdef, encrypt::enc_hmac_sha_256, fidokey::common, pintoken};
+use crate::{ctapdef, fidokey::common, pin_uv_auth_protocol, pintoken};
 use anyhow::Result;
 use ciborium::value::Value;
 use strum_macros::EnumProperty;
@@ -85,7 +85,7 @@ pub fn create_payload(
         let mut message = vec![sub_command.id()?];
         message.append(&mut sub_command_params_cbor.to_vec());
 
-        let pin_uv_auth_param = enc_hmac_sha_256::compute_pin_uv_auth_param(
+        let pin_uv_auth_param = pin_uv_auth_protocol::compute_pin_uv_auth_param(
             &pin_token.key,
             &message,
             pin_protocol_version,

--- a/src/fidokey/credential_management/credential_management_command.rs
+++ b/src/fidokey/credential_management/credential_management_command.rs
@@ -85,8 +85,11 @@ pub fn create_payload(
         let mut message = vec![sub_command.id()?];
         message.append(&mut sub_command_params_cbor.to_vec());
 
-        let sig = enc_hmac_sha_256::authenticate(&pin_token.key, &message);
-        let pin_uv_auth_param = sig[0..16].to_vec();
+        let pin_uv_auth_param = enc_hmac_sha_256::compute_pin_uv_auth_param(
+            &pin_token.key,
+            &message,
+            pin_protocol_version,
+        )?;
 
         map.push((0x04.to_value(), pin_uv_auth_param.to_value()));
     }

--- a/src/fidokey/get_assertion/get_assertion_command.rs
+++ b/src/fidokey/get_assertion/get_assertion_command.rs
@@ -100,7 +100,7 @@ fn create_extensions(
 
     // HMAC Secret Extension
     if let Some(hmac_ext) = hmac_ext {
-        let tmp = hmac_ext.shared_secret.public_key.to_value_cib().unwrap();
+        let tmp = hmac_ext.shared_secret.public_key().to_value_cib().unwrap();
         let param = vec![
             // keyAgreement(0x01)
             (1.to_value(), tmp),
@@ -108,6 +108,8 @@ fn create_extensions(
             (2.to_value(), hmac_ext.salt_enc.to_value()),
             // saltAuth(0x03)
             (3.to_value(), hmac_ext.salt_auth.to_value()),
+            // pinUvAuthProtocol(0x04)
+            (4.to_value(), hmac_ext.pin_protocol_version.to_value()),
         ];
 
         ext_val.push((

--- a/src/fidokey/get_assertion/get_assertion_response.rs
+++ b/src/fidokey/get_assertion/get_assertion_response.rs
@@ -1,7 +1,7 @@
 use super::get_assertion_params;
 use super::get_assertion_params::Extension;
 use crate::auth_data::Flags;
-use crate::hmac_ext::PinUvAuthSharedSecret;
+use crate::pin_uv_auth_protocol::PinUvAuthSharedSecret;
 use crate::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
 use crate::util_ciborium;
 use anyhow::Result;

--- a/src/fidokey/get_assertion/get_assertion_response.rs
+++ b/src/fidokey/get_assertion/get_assertion_response.rs
@@ -1,8 +1,7 @@
 use super::get_assertion_params;
 use super::get_assertion_params::Extension;
 use crate::auth_data::Flags;
-use crate::encrypt::enc_aes256_cbc;
-use crate::encrypt::shared_secret::SharedSecret;
+use crate::hmac_ext::PinUvAuthSharedSecret;
 use crate::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
 use crate::util_ciborium;
 use anyhow::Result;
@@ -12,7 +11,7 @@ use std::io::Cursor;
 fn parse_cbor_authdata(
     authdata: Vec<u8>,
     ass: &mut get_assertion_params::Assertion,
-    shared_secret: Option<&SharedSecret>,
+    shared_secret: Option<&PinUvAuthSharedSecret>,
 ) -> Result<()> {
     // copy
     ass.auth_data = authdata.to_vec();
@@ -64,10 +63,7 @@ fn parse_cbor_authdata(
                     let hmac_secret = util_ciborium::cbor_value_to_vec_u8(val)?;
 
                     // decrypt hmac_secret -> output1
-                    let output1 = enc_aes256_cbc::decrypt_message(
-                        &shared_secret.as_ref().unwrap().secret,
-                        &hmac_secret,
-                    );
+                    let output1 = shared_secret.as_ref().unwrap().decrypt(&hmac_secret)?;
 
                     if output1.len() == 32 {
                         let mut hmac_secret_0 = [0u8; 32];
@@ -101,7 +97,7 @@ fn parse_cbor_authdata(
 
 pub fn parse_cbor(
     bytes: &[u8],
-    shared_secret: Option<SharedSecret>,
+    shared_secret: Option<PinUvAuthSharedSecret>,
 ) -> Result<get_assertion_params::Assertion> {
     let mut ass = get_assertion_params::Assertion::default();
     let maps = util_ciborium::cbor_bytes_to_map(bytes)?;

--- a/src/fidokey/large_blobs/large_blobs_command.rs
+++ b/src/fidokey/large_blobs/large_blobs_command.rs
@@ -51,8 +51,11 @@ pub fn create_payload(
                 let hash = digest::digest(&digest::SHA256, &large_blob_array);
                 message.append(&mut hash.as_ref().to_vec());
 
-                let sig = enc_hmac_sha_256::authenticate(&pin_token.key, &message);
-                sig[0..16].to_vec()
+                enc_hmac_sha_256::compute_pin_uv_auth_param(
+                    &pin_token.key,
+                    &message,
+                    pin_protocol_version,
+                )?
             };
 
             map.push((0x05.to_value(), pin_uv_auth_param.to_value()));

--- a/src/fidokey/large_blobs/large_blobs_command.rs
+++ b/src/fidokey/large_blobs/large_blobs_command.rs
@@ -1,6 +1,6 @@
 use crate::crypto::digest;
 use crate::util_ciborium::ToValue;
-use crate::{ctapdef, encrypt::enc_hmac_sha_256, fidokey::common, pintoken::PinToken};
+use crate::{ctapdef, fidokey::common, pin_uv_auth_protocol, pintoken::PinToken};
 use anyhow::Result;
 
 pub fn create_payload(
@@ -51,7 +51,7 @@ pub fn create_payload(
                 let hash = digest::digest(&digest::SHA256, &large_blob_array);
                 message.append(&mut hash.as_ref().to_vec());
 
-                enc_hmac_sha_256::compute_pin_uv_auth_param(
+                pin_uv_auth_protocol::compute_pin_uv_auth_param(
                     &pin_token.key,
                     &message,
                     pin_protocol_version,

--- a/src/fidokey/pin/client_pin.rs
+++ b/src/fidokey/pin/client_pin.rs
@@ -273,34 +273,18 @@ impl FidoKeyHid {
     }
 }
 
-// pinAuth = LEFT(HMAC-SHA-256(sharedSecret, newPinEnc), 16)
 fn create_pin_auth_for_set_pin(
     shared_secret: &SharedSecret,
     new_pin_enc: &[u8],
 ) -> Result<Vec<u8>> {
-    // HMAC-SHA-256(sharedSecret, newPinEnc)
-    let sig = enc_hmac_sha_256::authenticate(&shared_secret.secret, new_pin_enc);
-
-    // left 16
-    let pin_auth = sig[0..16].to_vec();
-
-    Ok(pin_auth)
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret, new_pin_enc, 1)
 }
 
 fn create_pin_auth_for_set_pin2(
     shared_secret: &SharedSecret2,
     new_pin_enc: &[u8],
 ) -> Result<Vec<u8>> {
-    // HMAC-SHA-256(sharedSecret, message)
-    // If key is longer than 32 bytes, discard the excess. (This selects the HMAC-key portion of the shared secret. When key is the pinUvAuthToken, it is exactly 32 bytes long and thus this step has no effect.)
-    let key = shared_secret.secret[0..32].to_vec();
-    let sig = enc_hmac_sha_256::authenticate(&key, new_pin_enc);
-
-    // Return the result of computing HMAC-SHA-256 on key and message.
-    // 32byte
-    let pin_auth = sig.to_vec();
-
-    Ok(pin_auth)
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret[0..32], new_pin_enc, 2)
 }
 
 fn create_pin_auth_for_change_pin(
@@ -313,13 +297,7 @@ fn create_pin_auth_for_change_pin(
     message.append(&mut new_pin_enc.to_vec());
     message.append(&mut current_pin_hash_enc.to_vec());
 
-    // HMAC-SHA-256(sharedSecret, message)
-    let sig = enc_hmac_sha_256::authenticate(&shared_secret.secret, &message);
-
-    // left 16
-    let pin_auth = sig[0..16].to_vec();
-
-    Ok(pin_auth)
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret, &message, 1)
 }
 
 fn create_pin_auth_for_change_pin2(
@@ -332,16 +310,7 @@ fn create_pin_auth_for_change_pin2(
     message.append(&mut new_pin_enc.to_vec());
     message.append(&mut current_pin_hash_enc.to_vec());
 
-    // HMAC-SHA-256(sharedSecret, message)
-    // If key is longer than 32 bytes, discard the excess. (This selects the HMAC-key portion of the shared secret. When key is the pinUvAuthToken, it is exactly 32 bytes long and thus this step has no effect.)
-    let key = shared_secret.secret[0..32].to_vec();
-    let sig = enc_hmac_sha_256::authenticate(&key, &message);
-
-    // Return the result of computing HMAC-SHA-256 on key and message.
-    // 32byte
-    let pin_auth = sig.to_vec();
-
-    Ok(pin_auth)
+    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret[0..32], &message, 2)
 }
 
 fn padding_pin_64(pin: &str) -> Result<Vec<u8>> {

--- a/src/fidokey/pin/client_pin.rs
+++ b/src/fidokey/pin/client_pin.rs
@@ -27,19 +27,11 @@ impl FidoKeyHid {
     pub fn create_pin_auth(&self, pin: &str, client_data_hash: &[u8]) -> Result<Vec<u8>> {
         let pin_token = self.get_pin_token(pin)?;
 
-        let sig = enc_hmac_sha_256::authenticate(&pin_token.key, client_data_hash);
-
-        if self.pin_protocol_version == 2 {
-            // 6.5.8. PIN/UV Auth Protocol Two
-            // authenticate(key, message):
-            //   Return the result of computing HMAC-SHA-256 on key and message. (32 bytes)
-            Ok(sig.to_vec())
-        } else {
-            // 6.5.7. PIN/UV Auth Protocol One
-            // authenticate(key, message):
-            //   Return the first 16 bytes of the result of computing HMAC-SHA-256 on key and message.
-            Ok(sig[0..16].to_vec())
-        }
+        enc_hmac_sha_256::compute_pin_uv_auth_param(
+            &pin_token.key,
+            client_data_hash,
+            self.pin_protocol_version,
+        )
     }
 
     pub fn get_pin_token(&self, pin: &str) -> Result<PinToken> {

--- a/src/fidokey/pin/client_pin.rs
+++ b/src/fidokey/pin/client_pin.rs
@@ -3,14 +3,9 @@ use super::client_pin_command::Permission;
 use super::client_pin_command::SubCommand as PinCmd;
 use super::client_pin_response;
 use super::FidoKeyHid;
-use crate::crypto::rand;
-use crate::crypto::rand::SecureRandom;
 use crate::ctaphid;
 use crate::encrypt::cose;
-use crate::encrypt::enc_aes256_cbc;
-use crate::encrypt::shared_secret::SharedSecret;
-use crate::encrypt::shared_secret2::SharedSecret2;
-use crate::pin_uv_auth_protocol::{self, PinUvAuthProtocol};
+use crate::pin_uv_auth_protocol::{compute_pin_uv_auth_param, PinUvAuthSharedSecret};
 use crate::pintoken::PinToken;
 use anyhow::{anyhow, Result};
 
@@ -27,11 +22,7 @@ impl FidoKeyHid {
     pub fn create_pin_auth(&self, pin: &str, client_data_hash: &[u8]) -> Result<Vec<u8>> {
         let pin_token = self.get_pin_token(pin)?;
 
-        pin_uv_auth_protocol::compute_pin_uv_auth_param(
-            &pin_token.key,
-            client_data_hash,
-            self.pin_protocol_version,
-        )
+        compute_pin_uv_auth_param(&pin_token.key, client_data_hash, self.pin_protocol_version)
     }
 
     pub fn get_pin_token(&self, pin: &str) -> Result<PinToken> {
@@ -40,49 +31,26 @@ impl FidoKeyHid {
         }
 
         let authenticator_key_agreement = self.get_authenticator_key_agreement()?;
+        let shared_secret =
+            PinUvAuthSharedSecret::new(self.pin_protocol_version, &authenticator_key_agreement)?;
 
-        let pin_token_dec = match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
-            PinUvAuthProtocol::One => {
-                let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
-                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+        // Get pinHashEnc
+        let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-                let send_payload = client_pin_command::create_payload_get_pin_token(
-                    &shared_secret.public_key,
-                    &pin_hash_enc,
-                    self.pin_protocol_version,
-                )?;
+        let send_payload = client_pin_command::create_payload_get_pin_token(
+            shared_secret.public_key(),
+            &pin_hash_enc,
+            self.pin_protocol_version,
+        )?;
 
-                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+        let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-                // get pin_token (enc)
-                let mut pin_token_enc =
-                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+        // get pin_token (enc)
+        let pin_token_enc =
+            client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-                // pintoken -> dec(pintoken)
-                shared_secret.decrypt_token(&mut pin_token_enc)?
-            }
-            PinUvAuthProtocol::Two => {
-                let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
-                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
-
-                let send_payload = client_pin_command::create_payload_get_pin_token(
-                    &shared_secret.public_key,
-                    &pin_hash_enc,
-                    self.pin_protocol_version,
-                )?;
-
-                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
-
-                // get pin_token (enc)
-                let pin_token_enc =
-                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
-
-                // pintoken -> dec(pintoken)
-                shared_secret.decrypt_token(&pin_token_enc)?
-            }
-        };
-
-        Ok(pin_token_dec)
+        // pintoken -> dec(pintoken)
+        shared_secret.decrypt_token(&pin_token_enc)
     }
 
     pub fn get_pinuv_auth_token_with_permission(
@@ -95,57 +63,28 @@ impl FidoKeyHid {
         }
 
         let authenticator_key_agreement = self.get_authenticator_key_agreement()?;
+        let shared_secret =
+            PinUvAuthSharedSecret::new(self.pin_protocol_version, &authenticator_key_agreement)?;
 
-        let pin_token_dec = match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
-            PinUvAuthProtocol::One => {
-                // Get pinHashEnc
-                // - shared_secret.public_key -> platform KeyAgreement
-                let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
-                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+        // Get pinHashEnc
+        let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-                // Get pin token
-                let send_payload =
-                    client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
-                        &shared_secret.public_key,
-                        &pin_hash_enc,
-                        permission,
-                        self.pin_protocol_version,
-                    )?;
-                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+        // Get pin token
+        let send_payload =
+            client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
+                shared_secret.public_key(),
+                &pin_hash_enc,
+                permission,
+                self.pin_protocol_version,
+            )?;
+        let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-                // get pin_token (enc)
-                let mut pin_token_enc =
-                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+        // get pin_token (enc)
+        let pin_token_enc =
+            client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-                // pintoken -> dec(pintoken)
-                shared_secret.decrypt_token(&mut pin_token_enc)?
-            }
-            PinUvAuthProtocol::Two => {
-                // Get pinHashEnc
-                // - shared_secret.public_key -> platform KeyAgreement
-                let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
-                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
-
-                // Get pin token
-                let send_payload =
-                    client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
-                        &shared_secret.public_key,
-                        &pin_hash_enc,
-                        permission,
-                        self.pin_protocol_version,
-                    )?;
-                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
-
-                // get pin_token (enc)
-                let pin_token_enc =
-                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
-
-                // pintoken -> dec(pintoken)
-                shared_secret.decrypt_token(&pin_token_enc)?
-            }
-        };
-
-        Ok(pin_token_dec)
+        // pintoken -> dec(pintoken)
+        shared_secret.decrypt_token(&pin_token_enc)
     }
 
     pub fn set_new_pin_cmd(&self, pin: &str) -> Result<()> {
@@ -161,32 +100,17 @@ impl FidoKeyHid {
         let key_agreement =
             client_pin_response::parse_cbor_client_pin_get_keyagreement(&response_cbor)?;
 
-        // get public_key, pin_auth, new_pin_enc
-        let (public_key, pin_auth, new_pin_enc) =
-            match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
-                PinUvAuthProtocol::One => {
-                    let shared_secret = SharedSecret::new(&key_agreement)?;
+        let shared_secret = PinUvAuthSharedSecret::new(self.pin_protocol_version, &key_agreement)?;
 
-                    let new_pin_enc = create_new_pin_enc(&shared_secret, pin)?;
+        // newPinEnc: encrypt(shared secret, paddedPin)
+        let new_pin_enc = shared_secret.encrypt(&padding_pin_64(pin)?)?;
 
-                    let pin_auth = create_pin_auth_for_set_pin(&shared_secret, &new_pin_enc)?;
-
-                    (shared_secret.public_key, pin_auth, new_pin_enc)
-                }
-                PinUvAuthProtocol::Two => {
-                    let shared_secret = SharedSecret2::new(&key_agreement)?;
-
-                    let new_pin_enc = create_new_pin_enc2(&shared_secret, pin)?;
-
-                    let pin_auth = create_pin_auth_for_set_pin2(&shared_secret, &new_pin_enc)?;
-
-                    (shared_secret.public_key, pin_auth, new_pin_enc)
-                }
-            };
+        // pinUvAuthParam: authenticate(shared secret, newPinEnc)
+        let pin_auth = shared_secret.authenticate(&new_pin_enc)?;
 
         // set new pin
         let send_payload = client_pin_command::create_payload_set_pin(
-            &public_key,
+            shared_secret.public_key(),
             &pin_auth,
             &new_pin_enc,
             self.pin_protocol_version,
@@ -213,59 +137,24 @@ impl FidoKeyHid {
         let key_agreement =
             client_pin_response::parse_cbor_client_pin_get_keyagreement(&response_cbor)?;
 
-        // get public_key, pin_auth, new_pin_enc, current_pin_hash_enc
-        let (public_key, pin_auth, new_pin_enc, current_pin_hash_enc) =
-            match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
-                PinUvAuthProtocol::One => {
-                    let shared_secret = SharedSecret::new(&key_agreement)?;
+        let shared_secret = PinUvAuthSharedSecret::new(self.pin_protocol_version, &key_agreement)?;
 
-                    let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
+        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#changingExistingPin
+        // 6.5.5.6. Changing existing PIN
 
-                    let new_pin_enc = create_new_pin_enc(&shared_secret, new_pin)?;
+        // pinHashEnc: encrypt(shared secret, LEFT(SHA-256(curPin), 16))
+        let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
 
-                    let pin_auth = create_pin_auth_for_change_pin(
-                        &shared_secret,
-                        &new_pin_enc,
-                        &current_pin_hash_enc,
-                    )?;
+        // newPinEnc: encrypt(shared secret, paddedPin)
+        let new_pin_enc = shared_secret.encrypt(&padding_pin_64(new_pin)?)?;
 
-                    (
-                        shared_secret.public_key,
-                        pin_auth,
-                        new_pin_enc,
-                        current_pin_hash_enc.into(),
-                    )
-                }
-                PinUvAuthProtocol::Two => {
-                    // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#changingExistingPin
-                    // 6.5.5.6. Changing existing PIN
-
-                    let shared_secret = SharedSecret2::new(&key_agreement)?;
-
-                    // 4. pinHashEnc: The result of calling encrypt(shared secret, LEFT(SHA-256(curPin), 16)).
-                    let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
-
-                    // 5. newPinEnc: the result of calling encrypt(shared secret, paddedPin) where paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)
-                    let new_pin_enc = create_new_pin_enc2(&shared_secret, new_pin)?;
-
-                    // 6. pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc || pinHashEnc).
-                    let pin_auth = create_pin_auth_for_change_pin2(
-                        &shared_secret,
-                        &new_pin_enc,
-                        &current_pin_hash_enc,
-                    )?;
-
-                    (
-                        shared_secret.public_key,
-                        pin_auth,
-                        new_pin_enc,
-                        current_pin_hash_enc,
-                    )
-                }
-            };
+        // pinUvAuthParam: authenticate(shared secret, newPinEnc || pinHashEnc)
+        let mut message = new_pin_enc.clone();
+        message.extend_from_slice(&current_pin_hash_enc);
+        let pin_auth = shared_secret.authenticate(&message)?;
 
         let send_payload = client_pin_command::create_payload_change_pin(
-            &public_key,
+            shared_secret.public_key(),
             &pin_auth,
             &new_pin_enc,
             &current_pin_hash_enc,
@@ -276,46 +165,6 @@ impl FidoKeyHid {
 
         Ok(())
     }
-}
-
-fn create_pin_auth_for_set_pin(
-    shared_secret: &SharedSecret,
-    new_pin_enc: &[u8],
-) -> Result<Vec<u8>> {
-    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret, new_pin_enc, 1)
-}
-
-fn create_pin_auth_for_set_pin2(
-    shared_secret: &SharedSecret2,
-    new_pin_enc: &[u8],
-) -> Result<Vec<u8>> {
-    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret[0..32], new_pin_enc, 2)
-}
-
-fn create_pin_auth_for_change_pin(
-    shared_secret: &SharedSecret,
-    new_pin_enc: &[u8],
-    current_pin_hash_enc: &[u8],
-) -> Result<Vec<u8>> {
-    // source data
-    let mut message = vec![];
-    message.append(&mut new_pin_enc.to_vec());
-    message.append(&mut current_pin_hash_enc.to_vec());
-
-    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret, &message, 1)
-}
-
-fn create_pin_auth_for_change_pin2(
-    shared_secret: &SharedSecret2,
-    new_pin_enc: &[u8],
-    current_pin_hash_enc: &[u8],
-) -> Result<Vec<u8>> {
-    // source data
-    let mut message = vec![];
-    message.append(&mut new_pin_enc.to_vec());
-    message.append(&mut current_pin_hash_enc.to_vec());
-
-    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret[0..32], &message, 2)
 }
 
 fn padding_pin_64(pin: &str) -> Result<Vec<u8>> {
@@ -334,34 +183,4 @@ fn padding_pin_64(pin: &str) -> Result<Vec<u8>> {
     }
 
     Ok(bpin64)
-}
-
-// newPinEnc: AES256-CBC(sharedSecret, IV = 0, newPin)
-fn create_new_pin_enc(shared_secret: &SharedSecret, new_pin: &str) -> Result<Vec<u8>> {
-    let new_pin_64 = padding_pin_64(new_pin)?;
-
-    let new_pin_enc = enc_aes256_cbc::encrypt_message(&shared_secret.secret, &new_pin_64);
-
-    Ok(new_pin_enc)
-}
-fn create_new_pin_enc2(shared_secret: &SharedSecret2, new_pin: &str) -> Result<Vec<u8>> {
-    let new_pin_64 = padding_pin_64(new_pin)?;
-
-    let aes_key: &[u8; 32] = shared_secret.secret[32..].try_into()?;
-
-    // Let iv be a 16-byte, random bytestring.
-    let mut iv = [0u8; 16];
-    let rng = rand::SystemRandom::new();
-    rng.fill(&mut iv)
-        .map_err(|_| anyhow!("Failed to generate random IV"))?;
-
-    let ciphertext = enc_aes256_cbc::encrypt_message_with_iv(aes_key, &iv, &new_pin_64);
-
-    // Return iv || ct.
-    // Concatenate iv and ct(ciphertext)
-    let mut new_pin_enc = vec![];
-    new_pin_enc.extend_from_slice(&iv);
-    new_pin_enc.extend_from_slice(&ciphertext);
-
-    Ok(new_pin_enc)
 }

--- a/src/fidokey/pin/client_pin.rs
+++ b/src/fidokey/pin/client_pin.rs
@@ -8,9 +8,9 @@ use crate::crypto::rand::SecureRandom;
 use crate::ctaphid;
 use crate::encrypt::cose;
 use crate::encrypt::enc_aes256_cbc;
-use crate::encrypt::enc_hmac_sha_256;
 use crate::encrypt::shared_secret::SharedSecret;
 use crate::encrypt::shared_secret2::SharedSecret2;
+use crate::pin_uv_auth_protocol::{self, PinUvAuthProtocol};
 use crate::pintoken::PinToken;
 use anyhow::{anyhow, Result};
 
@@ -27,7 +27,7 @@ impl FidoKeyHid {
     pub fn create_pin_auth(&self, pin: &str, client_data_hash: &[u8]) -> Result<Vec<u8>> {
         let pin_token = self.get_pin_token(pin)?;
 
-        enc_hmac_sha_256::compute_pin_uv_auth_param(
+        pin_uv_auth_protocol::compute_pin_uv_auth_param(
             &pin_token.key,
             client_data_hash,
             self.pin_protocol_version,
@@ -41,44 +41,45 @@ impl FidoKeyHid {
 
         let authenticator_key_agreement = self.get_authenticator_key_agreement()?;
 
-        let pin_token_dec = if self.pin_protocol_version == 1 {
-            let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
-            let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+        let pin_token_dec = match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
+            PinUvAuthProtocol::One => {
+                let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
+                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-            let send_payload = client_pin_command::create_payload_get_pin_token(
-                &shared_secret.public_key,
-                &pin_hash_enc,
-                self.pin_protocol_version,
-            )?;
+                let send_payload = client_pin_command::create_payload_get_pin_token(
+                    &shared_secret.public_key,
+                    &pin_hash_enc,
+                    self.pin_protocol_version,
+                )?;
 
-            let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-            // get pin_token (enc)
-            let mut pin_token_enc =
-                client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+                // get pin_token (enc)
+                let mut pin_token_enc =
+                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-            // pintoken -> dec(pintoken)
-            shared_secret.decrypt_token(&mut pin_token_enc)?
-        } else if self.pin_protocol_version == 2 {
-            let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
-            let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+                // pintoken -> dec(pintoken)
+                shared_secret.decrypt_token(&mut pin_token_enc)?
+            }
+            PinUvAuthProtocol::Two => {
+                let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
+                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-            let send_payload = client_pin_command::create_payload_get_pin_token(
-                &shared_secret.public_key,
-                &pin_hash_enc,
-                self.pin_protocol_version,
-            )?;
+                let send_payload = client_pin_command::create_payload_get_pin_token(
+                    &shared_secret.public_key,
+                    &pin_hash_enc,
+                    self.pin_protocol_version,
+                )?;
 
-            let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-            // get pin_token (enc)
-            let pin_token_enc =
-                client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+                // get pin_token (enc)
+                let pin_token_enc =
+                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-            // pintoken -> dec(pintoken)
-            shared_secret.decrypt_token(&pin_token_enc)?
-        } else {
-            return Err(anyhow!("unknown pin_protocol_version"));
+                // pintoken -> dec(pintoken)
+                shared_secret.decrypt_token(&pin_token_enc)?
+            }
         };
 
         Ok(pin_token_dec)
@@ -95,52 +96,53 @@ impl FidoKeyHid {
 
         let authenticator_key_agreement = self.get_authenticator_key_agreement()?;
 
-        let pin_token_dec = if self.pin_protocol_version == 1 {
-            // Get pinHashEnc
-            // - shared_secret.public_key -> platform KeyAgreement
-            let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
-            let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+        let pin_token_dec = match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
+            PinUvAuthProtocol::One => {
+                // Get pinHashEnc
+                // - shared_secret.public_key -> platform KeyAgreement
+                let shared_secret = SharedSecret::new(&authenticator_key_agreement)?;
+                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-            // Get pin token
-            let send_payload =
-                client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
-                    &shared_secret.public_key,
-                    &pin_hash_enc,
-                    permission,
-                    self.pin_protocol_version,
-                )?;
-            let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+                // Get pin token
+                let send_payload =
+                    client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
+                        &shared_secret.public_key,
+                        &pin_hash_enc,
+                        permission,
+                        self.pin_protocol_version,
+                    )?;
+                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-            // get pin_token (enc)
-            let mut pin_token_enc =
-                client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+                // get pin_token (enc)
+                let mut pin_token_enc =
+                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-            // pintoken -> dec(pintoken)
-            shared_secret.decrypt_token(&mut pin_token_enc)?
-        } else if self.pin_protocol_version == 2 {
-            // Get pinHashEnc
-            // - shared_secret.public_key -> platform KeyAgreement
-            let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
-            let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
+                // pintoken -> dec(pintoken)
+                shared_secret.decrypt_token(&mut pin_token_enc)?
+            }
+            PinUvAuthProtocol::Two => {
+                // Get pinHashEnc
+                // - shared_secret.public_key -> platform KeyAgreement
+                let shared_secret = SharedSecret2::new(&authenticator_key_agreement)?;
+                let pin_hash_enc = shared_secret.encrypt_pin(pin)?;
 
-            // Get pin token
-            let send_payload =
-                client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
-                    &shared_secret.public_key,
-                    &pin_hash_enc,
-                    permission,
-                    self.pin_protocol_version,
-                )?;
-            let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
+                // Get pin token
+                let send_payload =
+                    client_pin_command::create_payload_get_pin_uv_auth_token_using_pin_with_permissions(
+                        &shared_secret.public_key,
+                        &pin_hash_enc,
+                        permission,
+                        self.pin_protocol_version,
+                    )?;
+                let response_cbor = ctaphid::ctaphid_cbor(self, &send_payload)?;
 
-            // get pin_token (enc)
-            let pin_token_enc =
-                client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
+                // get pin_token (enc)
+                let pin_token_enc =
+                    client_pin_response::parse_cbor_client_pin_get_pin_token(&response_cbor)?;
 
-            // pintoken -> dec(pintoken)
-            shared_secret.decrypt_token(&pin_token_enc)?
-        } else {
-            return Err(anyhow!("unknown pin_protocol_version"));
+                // pintoken -> dec(pintoken)
+                shared_secret.decrypt_token(&pin_token_enc)?
+            }
         };
 
         Ok(pin_token_dec)
@@ -160,25 +162,27 @@ impl FidoKeyHid {
             client_pin_response::parse_cbor_client_pin_get_keyagreement(&response_cbor)?;
 
         // get public_key, pin_auth, new_pin_enc
-        let (public_key, pin_auth, new_pin_enc) = if self.pin_protocol_version == 1 {
-            let shared_secret = SharedSecret::new(&key_agreement)?;
+        let (public_key, pin_auth, new_pin_enc) =
+            match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
+                PinUvAuthProtocol::One => {
+                    let shared_secret = SharedSecret::new(&key_agreement)?;
 
-            let new_pin_enc = create_new_pin_enc(&shared_secret, pin)?;
+                    let new_pin_enc = create_new_pin_enc(&shared_secret, pin)?;
 
-            let pin_auth = create_pin_auth_for_set_pin(&shared_secret, &new_pin_enc)?;
+                    let pin_auth = create_pin_auth_for_set_pin(&shared_secret, &new_pin_enc)?;
 
-            (shared_secret.public_key, pin_auth, new_pin_enc)
-        } else if self.pin_protocol_version == 2 {
-            let shared_secret = SharedSecret2::new(&key_agreement)?;
+                    (shared_secret.public_key, pin_auth, new_pin_enc)
+                }
+                PinUvAuthProtocol::Two => {
+                    let shared_secret = SharedSecret2::new(&key_agreement)?;
 
-            let new_pin_enc = create_new_pin_enc2(&shared_secret, pin)?;
+                    let new_pin_enc = create_new_pin_enc2(&shared_secret, pin)?;
 
-            let pin_auth = create_pin_auth_for_set_pin2(&shared_secret, &new_pin_enc)?;
+                    let pin_auth = create_pin_auth_for_set_pin2(&shared_secret, &new_pin_enc)?;
 
-            (shared_secret.public_key, pin_auth, new_pin_enc)
-        } else {
-            return Err(anyhow!("unknown pin_protocol_version"));
-        };
+                    (shared_secret.public_key, pin_auth, new_pin_enc)
+                }
+            };
 
         // set new pin
         let send_payload = client_pin_command::create_payload_set_pin(
@@ -211,52 +215,53 @@ impl FidoKeyHid {
 
         // get public_key, pin_auth, new_pin_enc, current_pin_hash_enc
         let (public_key, pin_auth, new_pin_enc, current_pin_hash_enc) =
-            if self.pin_protocol_version == 1 {
-                let shared_secret = SharedSecret::new(&key_agreement)?;
+            match PinUvAuthProtocol::from_version(self.pin_protocol_version)? {
+                PinUvAuthProtocol::One => {
+                    let shared_secret = SharedSecret::new(&key_agreement)?;
 
-                let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
+                    let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
 
-                let new_pin_enc = create_new_pin_enc(&shared_secret, new_pin)?;
+                    let new_pin_enc = create_new_pin_enc(&shared_secret, new_pin)?;
 
-                let pin_auth = create_pin_auth_for_change_pin(
-                    &shared_secret,
-                    &new_pin_enc,
-                    &current_pin_hash_enc,
-                )?;
+                    let pin_auth = create_pin_auth_for_change_pin(
+                        &shared_secret,
+                        &new_pin_enc,
+                        &current_pin_hash_enc,
+                    )?;
 
-                (
-                    shared_secret.public_key,
-                    pin_auth,
-                    new_pin_enc,
-                    current_pin_hash_enc.into(),
-                )
-            } else if self.pin_protocol_version == 2 {
-                // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#changingExistingPin
-                // 6.5.5.6. Changing existing PIN
+                    (
+                        shared_secret.public_key,
+                        pin_auth,
+                        new_pin_enc,
+                        current_pin_hash_enc.into(),
+                    )
+                }
+                PinUvAuthProtocol::Two => {
+                    // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#changingExistingPin
+                    // 6.5.5.6. Changing existing PIN
 
-                let shared_secret = SharedSecret2::new(&key_agreement)?;
+                    let shared_secret = SharedSecret2::new(&key_agreement)?;
 
-                // 4. pinHashEnc: The result of calling encrypt(shared secret, LEFT(SHA-256(curPin), 16)).
-                let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
+                    // 4. pinHashEnc: The result of calling encrypt(shared secret, LEFT(SHA-256(curPin), 16)).
+                    let current_pin_hash_enc = shared_secret.encrypt_pin(current_pin)?;
 
-                // 5. newPinEnc: the result of calling encrypt(shared secret, paddedPin) where paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)
-                let new_pin_enc = create_new_pin_enc2(&shared_secret, new_pin)?;
+                    // 5. newPinEnc: the result of calling encrypt(shared secret, paddedPin) where paddedPin is newPin padded on the right with 0x00 bytes to make it 64 bytes long. (Since the maximum length of newPin is 63 bytes, there is always at least one byte of padding.)
+                    let new_pin_enc = create_new_pin_enc2(&shared_secret, new_pin)?;
 
-                // 6. pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc || pinHashEnc).
-                let pin_auth = create_pin_auth_for_change_pin2(
-                    &shared_secret,
-                    &new_pin_enc,
-                    &current_pin_hash_enc,
-                )?;
+                    // 6. pinUvAuthParam: the result of calling authenticate(shared secret, newPinEnc || pinHashEnc).
+                    let pin_auth = create_pin_auth_for_change_pin2(
+                        &shared_secret,
+                        &new_pin_enc,
+                        &current_pin_hash_enc,
+                    )?;
 
-                (
-                    shared_secret.public_key,
-                    pin_auth,
-                    new_pin_enc,
-                    current_pin_hash_enc,
-                )
-            } else {
-                return Err(anyhow!("unknown pin_protocol_version"));
+                    (
+                        shared_secret.public_key,
+                        pin_auth,
+                        new_pin_enc,
+                        current_pin_hash_enc,
+                    )
+                }
             };
 
         let send_payload = client_pin_command::create_payload_change_pin(
@@ -277,14 +282,14 @@ fn create_pin_auth_for_set_pin(
     shared_secret: &SharedSecret,
     new_pin_enc: &[u8],
 ) -> Result<Vec<u8>> {
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret, new_pin_enc, 1)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret, new_pin_enc, 1)
 }
 
 fn create_pin_auth_for_set_pin2(
     shared_secret: &SharedSecret2,
     new_pin_enc: &[u8],
 ) -> Result<Vec<u8>> {
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret[0..32], new_pin_enc, 2)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret[0..32], new_pin_enc, 2)
 }
 
 fn create_pin_auth_for_change_pin(
@@ -297,7 +302,7 @@ fn create_pin_auth_for_change_pin(
     message.append(&mut new_pin_enc.to_vec());
     message.append(&mut current_pin_hash_enc.to_vec());
 
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret, &message, 1)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret, &message, 1)
 }
 
 fn create_pin_auth_for_change_pin2(
@@ -310,7 +315,7 @@ fn create_pin_auth_for_change_pin2(
     message.append(&mut new_pin_enc.to_vec());
     message.append(&mut current_pin_hash_enc.to_vec());
 
-    enc_hmac_sha_256::compute_pin_uv_auth_param(&shared_secret.secret[0..32], &message, 2)
+    pin_uv_auth_protocol::compute_pin_uv_auth_param(&shared_secret.secret[0..32], &message, 2)
 }
 
 fn padding_pin_64(pin: &str) -> Result<Vec<u8>> {

--- a/src/fidokey/pin/client_pin.rs
+++ b/src/fidokey/pin/client_pin.rs
@@ -27,19 +27,19 @@ impl FidoKeyHid {
     pub fn create_pin_auth(&self, pin: &str, client_data_hash: &[u8]) -> Result<Vec<u8>> {
         let pin_token = self.get_pin_token(pin)?;
 
-        //
-        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto2
-        //
-        // 6.5.7. PIN/UV Auth Protocol Two
-        // [authenticate(key, message) → signature]
-        //
-
-        // 1. If key is longer than 32 bytes, discard the excess. (This selects the HMAC-key portion of the shared secret. When key is the pinUvAuthToken, it is exactly 32 bytes long and thus this step has no effect.)
-        // skip
-
-        // 2. Return the result of computing HMAC-SHA-256 on key and message.
         let sig = enc_hmac_sha_256::authenticate(&pin_token.key, client_data_hash);
-        Ok(sig[0..16].to_vec())
+
+        if self.pin_protocol_version == 2 {
+            // 6.5.8. PIN/UV Auth Protocol Two
+            // authenticate(key, message):
+            //   Return the result of computing HMAC-SHA-256 on key and message. (32 bytes)
+            Ok(sig.to_vec())
+        } else {
+            // 6.5.7. PIN/UV Auth Protocol One
+            // authenticate(key, message):
+            //   Return the first 16 bytes of the result of computing HMAC-SHA-256 on key and message.
+            Ok(sig[0..16].to_vec())
+        }
     }
 
     pub fn get_pin_token(&self, pin: &str) -> Result<PinToken> {

--- a/src/fidokey/pin/mod.rs
+++ b/src/fidokey/pin/mod.rs
@@ -46,31 +46,3 @@ impl FidoKeyHid {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::SubCommand as PinCmd;
-    use super::*;
-    use crate::ctaphid;
-    use crate::fidokey::FidoKeyHid;
-    use crate::Cfg;
-    use crate::HidParam;
-
-    #[test]
-    fn test_client_pin_get_keyagreement() {
-        let hid_params = HidParam::get();
-        let device = FidoKeyHid::new(&hid_params, &Cfg::init()).unwrap();
-
-        let send_payload =
-            create_payload(PinCmd::GetKeyAgreement, device.pin_protocol_version).unwrap();
-        // The cid is obtained internally by ctaphid_cbor
-        let response_cbor = ctaphid::ctaphid_cbor(&device, &send_payload).unwrap();
-
-        let key_agreement =
-            client_pin_response::parse_cbor_client_pin_get_keyagreement(&response_cbor).unwrap();
-        println!("authenticatorClientPIN (0x06) - getKeyAgreement");
-        println!("{}", key_agreement);
-
-        assert!(true);
-    }
-}

--- a/src/hmac_ext.rs
+++ b/src/hmac_ext.rs
@@ -50,7 +50,7 @@ impl HmacExt {
         self.salt_auth = shared_secret.authenticate(&self.salt_enc)?;
         //println!("{}", StrBuf::bufh("salt_auth", &self.salt_auth));
 
-        self.pin_protocol_version = shared_secret.pin_protocol_version();
+        self.pin_protocol_version = device.pin_protocol_version;
         self.shared_secret = shared_secret;
 
         Ok(())

--- a/src/hmac_ext.rs
+++ b/src/hmac_ext.rs
@@ -1,18 +1,96 @@
 use crate::ctaphid;
-use crate::encrypt::enc_aes256_cbc;
+use crate::encrypt::cose::CoseKey;
 use crate::encrypt::enc_hmac_sha_256;
 use crate::encrypt::shared_secret::SharedSecret;
+use crate::encrypt::shared_secret2::SharedSecret2;
 use crate::fidokey::pin::{
     create_payload, parse_cbor_client_pin_get_keyagreement, SubCommand as PinCmd,
 };
 use crate::FidoKeyHid;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+
+/// A PIN/UV Auth Protocol shared secret, in whichever protocol version was negotiated.
+///
+/// Centralizes the Protocol One vs Protocol Two split (key material, encrypt/decrypt,
+/// and HMAC truncation rules) so callers that need a shared secret for something other
+/// than the pinUvAuthToken flow (e.g. the hmac-secret extension) don't have to
+/// re-implement the split themselves.
+#[derive(Debug, Clone)]
+pub enum PinUvAuthSharedSecret {
+    One(SharedSecret),
+    Two(SharedSecret2),
+}
+
+impl Default for PinUvAuthSharedSecret {
+    fn default() -> Self {
+        Self::One(SharedSecret::default())
+    }
+}
+
+impl PinUvAuthSharedSecret {
+    pub fn new(pin_protocol_version: u8, key_agreement: &CoseKey) -> Result<Self> {
+        match pin_protocol_version {
+            1 => Ok(Self::One(SharedSecret::new(key_agreement)?)),
+            2 => Ok(Self::Two(SharedSecret2::new(key_agreement)?)),
+            _ => Err(anyhow!("unknown pin_protocol_version")),
+        }
+    }
+
+    pub fn public_key(&self) -> &CoseKey {
+        match self {
+            Self::One(s) => &s.public_key,
+            Self::Two(s) => &s.public_key,
+        }
+    }
+
+    pub fn pin_protocol_version(&self) -> u8 {
+        match self {
+            Self::One(_) => 1,
+            Self::Two(_) => 2,
+        }
+    }
+
+    /// The key used for authenticate()/HMAC-SHA-256. Protocol Two discards the
+    /// AES-key half of the shared secret, keeping only the HMAC-key half.
+    fn auth_key(&self) -> &[u8] {
+        match self {
+            Self::One(s) => &s.secret,
+            Self::Two(s) => &s.secret[0..32],
+        }
+    }
+
+    /// encrypt(key, demPlaintext) → ciphertext, per the negotiated protocol version.
+    pub fn encrypt(&self, dem_plaintext: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            Self::One(s) => Ok(s.encrypt_raw(dem_plaintext)),
+            Self::Two(s) => s.encrypt(dem_plaintext),
+        }
+    }
+
+    /// decrypt(key, demCiphertext) → plaintext, per the negotiated protocol version.
+    pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            Self::One(s) => Ok(s.decrypt_raw(dem_cipher_text)),
+            Self::Two(s) => s.decrypt(dem_cipher_text),
+        }
+    }
+
+    /// authenticate(key, message) → pinUvAuthParam, per the negotiated protocol version.
+    pub fn authenticate(&self, message: &[u8]) -> Result<Vec<u8>> {
+        enc_hmac_sha_256::compute_pin_uv_auth_param(
+            self.auth_key(),
+            message,
+            self.pin_protocol_version(),
+        )
+    }
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct HmacExt {
-    pub shared_secret: SharedSecret,
+    pub shared_secret: PinUvAuthSharedSecret,
     pub salt_enc: Vec<u8>,
     pub salt_auth: Vec<u8>,
+    pub pin_protocol_version: u8,
 }
 
 impl HmacExt {
@@ -27,7 +105,9 @@ impl HmacExt {
 
         let key_agreement = parse_cbor_client_pin_get_keyagreement(&response_cbor)?;
 
-        self.shared_secret = SharedSecret::new(&key_agreement)?;
+        let shared_secret =
+            PinUvAuthSharedSecret::new(device.pin_protocol_version, &key_agreement)?;
+
         let mut salt = salt1.to_vec();
         if let Some(s) = salt2 {
             // println!("second salt");
@@ -42,14 +122,74 @@ impl HmacExt {
         //  encrypt(key, demPlaintext) → ciphertext
         //      Encrypts a plaintext to produce a ciphertext, which may be longer than the plaintext.
         //      The plaintext is restricted to being a multiple of the AES block size (16 bytes) in length.
-        self.salt_enc = enc_aes256_cbc::encrypt_message(&self.shared_secret.secret, &salt);
+        self.salt_enc = shared_secret.encrypt(&salt)?;
         //println!("{}", StrBuf::bufh("salt_enc", &self.salt_enc));
 
-        // saltAuth
-        let sig = enc_hmac_sha_256::authenticate(&self.shared_secret.secret, &self.salt_enc);
-        self.salt_auth = sig[0..16].to_vec();
+        // saltAuth: authenticate(shared secret, saltEnc)
+        self.salt_auth = shared_secret.authenticate(&self.salt_enc)?;
         //println!("{}", StrBuf::bufh("salt_auth", &self.salt_auth));
 
+        self.pin_protocol_version = shared_secret.pin_protocol_version();
+        self.shared_secret = shared_secret;
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one() -> PinUvAuthSharedSecret {
+        PinUvAuthSharedSecret::One(SharedSecret {
+            secret: [3u8; 32],
+            public_key: CoseKey::default(),
+        })
+    }
+
+    fn two() -> PinUvAuthSharedSecret {
+        let mut secret = [0u8; 64];
+        secret[..32].copy_from_slice(&[1u8; 32]); // HMAC-key half
+        secret[32..].copy_from_slice(&[2u8; 32]); // AES-key half
+        PinUvAuthSharedSecret::Two(SharedSecret2 {
+            secret,
+            public_key: CoseKey::default(),
+        })
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_protocol_versions() {
+        assert_eq!(one().pin_protocol_version(), 1);
+        assert_eq!(two().pin_protocol_version(), 2);
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_encrypt_decrypt_roundtrip() {
+        let salt = [9u8; 32];
+
+        for shared_secret in [one(), two()] {
+            let salt_enc = shared_secret.encrypt(&salt).unwrap();
+            let decrypted = shared_secret.decrypt(&salt_enc).unwrap();
+            assert_eq!(decrypted, salt);
+        }
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_authenticate_length() {
+        let message = [5u8; 32];
+
+        // Protocol One truncates to 16 bytes.
+        let param_one = one().authenticate(&message).unwrap();
+        assert_eq!(param_one.len(), 16);
+
+        // Protocol Two returns the full 32-byte HMAC-SHA-256 output.
+        let param_two = two().authenticate(&message).unwrap();
+        assert_eq!(param_two.len(), 32);
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_new_rejects_unknown_protocol() {
+        let result = PinUvAuthSharedSecret::new(3, &CoseKey::default());
+        assert!(result.is_err());
     }
 }

--- a/src/hmac_ext.rs
+++ b/src/hmac_ext.rs
@@ -1,88 +1,10 @@
 use crate::ctaphid;
-use crate::encrypt::cose::CoseKey;
-use crate::encrypt::shared_secret::SharedSecret;
-use crate::encrypt::shared_secret2::SharedSecret2;
 use crate::fidokey::pin::{
     create_payload, parse_cbor_client_pin_get_keyagreement, SubCommand as PinCmd,
 };
-use crate::pin_uv_auth_protocol::{self, PinUvAuthProtocol};
+use crate::pin_uv_auth_protocol::PinUvAuthSharedSecret;
 use crate::FidoKeyHid;
 use anyhow::Result;
-
-/// A PIN/UV Auth Protocol shared secret, in whichever protocol version was negotiated.
-///
-/// Centralizes the Protocol One vs Protocol Two split (key material, encrypt/decrypt,
-/// and HMAC truncation rules) so callers that need a shared secret for something other
-/// than the pinUvAuthToken flow (e.g. the hmac-secret extension) don't have to
-/// re-implement the split themselves.
-#[derive(Debug, Clone)]
-pub enum PinUvAuthSharedSecret {
-    One(SharedSecret),
-    Two(SharedSecret2),
-}
-
-impl Default for PinUvAuthSharedSecret {
-    fn default() -> Self {
-        Self::One(SharedSecret::default())
-    }
-}
-
-impl PinUvAuthSharedSecret {
-    pub fn new(pin_protocol_version: u8, key_agreement: &CoseKey) -> Result<Self> {
-        match PinUvAuthProtocol::from_version(pin_protocol_version)? {
-            PinUvAuthProtocol::One => Ok(Self::One(SharedSecret::new(key_agreement)?)),
-            PinUvAuthProtocol::Two => Ok(Self::Two(SharedSecret2::new(key_agreement)?)),
-        }
-    }
-
-    pub fn public_key(&self) -> &CoseKey {
-        match self {
-            Self::One(s) => &s.public_key,
-            Self::Two(s) => &s.public_key,
-        }
-    }
-
-    pub fn pin_protocol_version(&self) -> u8 {
-        match self {
-            Self::One(_) => PinUvAuthProtocol::One.version(),
-            Self::Two(_) => PinUvAuthProtocol::Two.version(),
-        }
-    }
-
-    /// The key used for authenticate()/HMAC-SHA-256. Protocol Two discards the
-    /// AES-key half of the shared secret, keeping only the HMAC-key half.
-    fn auth_key(&self) -> &[u8] {
-        match self {
-            Self::One(s) => &s.secret,
-            Self::Two(s) => &s.secret[0..32],
-        }
-    }
-
-    /// encrypt(key, demPlaintext) → ciphertext, per the negotiated protocol version.
-    pub fn encrypt(&self, dem_plaintext: &[u8]) -> Result<Vec<u8>> {
-        match self {
-            Self::One(s) => Ok(s.encrypt_raw(dem_plaintext)),
-            Self::Two(s) => s.encrypt(dem_plaintext),
-        }
-    }
-
-    /// decrypt(key, demCiphertext) → plaintext, per the negotiated protocol version.
-    pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Result<Vec<u8>> {
-        match self {
-            Self::One(s) => Ok(s.decrypt_raw(dem_cipher_text)),
-            Self::Two(s) => s.decrypt(dem_cipher_text),
-        }
-    }
-
-    /// authenticate(key, message) → pinUvAuthParam, per the negotiated protocol version.
-    pub fn authenticate(&self, message: &[u8]) -> Result<Vec<u8>> {
-        pin_uv_auth_protocol::compute_pin_uv_auth_param(
-            self.auth_key(),
-            message,
-            self.pin_protocol_version(),
-        )
-    }
-}
 
 #[derive(Debug, Default, Clone)]
 pub struct HmacExt {
@@ -132,63 +54,5 @@ impl HmacExt {
         self.shared_secret = shared_secret;
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn one() -> PinUvAuthSharedSecret {
-        PinUvAuthSharedSecret::One(SharedSecret {
-            secret: [3u8; 32],
-            public_key: CoseKey::default(),
-        })
-    }
-
-    fn two() -> PinUvAuthSharedSecret {
-        let mut secret = [0u8; 64];
-        secret[..32].copy_from_slice(&[1u8; 32]); // HMAC-key half
-        secret[32..].copy_from_slice(&[2u8; 32]); // AES-key half
-        PinUvAuthSharedSecret::Two(SharedSecret2 {
-            secret,
-            public_key: CoseKey::default(),
-        })
-    }
-
-    #[test]
-    fn test_pin_uv_auth_shared_secret_protocol_versions() {
-        assert_eq!(one().pin_protocol_version(), 1);
-        assert_eq!(two().pin_protocol_version(), 2);
-    }
-
-    #[test]
-    fn test_pin_uv_auth_shared_secret_encrypt_decrypt_roundtrip() {
-        let salt = [9u8; 32];
-
-        for shared_secret in [one(), two()] {
-            let salt_enc = shared_secret.encrypt(&salt).unwrap();
-            let decrypted = shared_secret.decrypt(&salt_enc).unwrap();
-            assert_eq!(decrypted, salt);
-        }
-    }
-
-    #[test]
-    fn test_pin_uv_auth_shared_secret_authenticate_length() {
-        let message = [5u8; 32];
-
-        // Protocol One truncates to 16 bytes.
-        let param_one = one().authenticate(&message).unwrap();
-        assert_eq!(param_one.len(), 16);
-
-        // Protocol Two returns the full 32-byte HMAC-SHA-256 output.
-        let param_two = two().authenticate(&message).unwrap();
-        assert_eq!(param_two.len(), 32);
-    }
-
-    #[test]
-    fn test_pin_uv_auth_shared_secret_new_rejects_unknown_protocol() {
-        let result = PinUvAuthSharedSecret::new(3, &CoseKey::default());
-        assert!(result.is_err());
     }
 }

--- a/src/hmac_ext.rs
+++ b/src/hmac_ext.rs
@@ -1,13 +1,13 @@
 use crate::ctaphid;
 use crate::encrypt::cose::CoseKey;
-use crate::encrypt::enc_hmac_sha_256;
 use crate::encrypt::shared_secret::SharedSecret;
 use crate::encrypt::shared_secret2::SharedSecret2;
 use crate::fidokey::pin::{
     create_payload, parse_cbor_client_pin_get_keyagreement, SubCommand as PinCmd,
 };
+use crate::pin_uv_auth_protocol::{self, PinUvAuthProtocol};
 use crate::FidoKeyHid;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 /// A PIN/UV Auth Protocol shared secret, in whichever protocol version was negotiated.
 ///
@@ -29,10 +29,9 @@ impl Default for PinUvAuthSharedSecret {
 
 impl PinUvAuthSharedSecret {
     pub fn new(pin_protocol_version: u8, key_agreement: &CoseKey) -> Result<Self> {
-        match pin_protocol_version {
-            1 => Ok(Self::One(SharedSecret::new(key_agreement)?)),
-            2 => Ok(Self::Two(SharedSecret2::new(key_agreement)?)),
-            _ => Err(anyhow!("unknown pin_protocol_version")),
+        match PinUvAuthProtocol::from_version(pin_protocol_version)? {
+            PinUvAuthProtocol::One => Ok(Self::One(SharedSecret::new(key_agreement)?)),
+            PinUvAuthProtocol::Two => Ok(Self::Two(SharedSecret2::new(key_agreement)?)),
         }
     }
 
@@ -45,8 +44,8 @@ impl PinUvAuthSharedSecret {
 
     pub fn pin_protocol_version(&self) -> u8 {
         match self {
-            Self::One(_) => 1,
-            Self::Two(_) => 2,
+            Self::One(_) => PinUvAuthProtocol::One.version(),
+            Self::Two(_) => PinUvAuthProtocol::Two.version(),
         }
     }
 
@@ -77,7 +76,7 @@ impl PinUvAuthSharedSecret {
 
     /// authenticate(key, message) → pinUvAuthParam, per the negotiated protocol version.
     pub fn authenticate(&self, message: &[u8]) -> Result<Vec<u8>> {
-        enc_hmac_sha_256::compute_pin_uv_auth_param(
+        pin_uv_auth_protocol::compute_pin_uv_auth_param(
             self.auth_key(),
             message,
             self.pin_protocol_version(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,21 @@ mod tests {
     }
 
     #[test]
+    fn test_create_pin_auth_protocol_two() {
+        // PIN/UV Auth Protocol Two returns the full 32-byte HMAC-SHA-256 output
+        // without truncation (CTAP 2.2 6.5.8. authenticate(key, message)).
+        let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
+        let client_data_hash =
+            hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
+                .unwrap();
+        let check =
+            "F0AC99D6AAD2E199AF9CF25F6568A6F555D6394CDC35D81573D71A3B3CB275F3".to_string();
+        let pin_auth = encrypt::enc_hmac_sha_256::authenticate(&out_bytes, &client_data_hash);
+        assert_eq!(pin_auth.len(), 32);
+        assert_eq!(check, hex::encode(pin_auth).to_uppercase());
+    }
+
+    #[test]
     fn test_hmac() {
         let key = b"this is key".to_vec();
         let message = b"this is message".to_vec();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod encrypt {
     pub mod shared_secret2;
 }
 mod hmac_ext;
+mod pin_uv_auth_protocol;
 mod pintoken;
 pub mod public_key;
 pub mod public_key_credential_descriptor;
@@ -134,7 +135,7 @@ mod tests {
                 .unwrap();
         let check = "F0AC99D6AAD2E199AF9CF25F6568A6F5".to_string();
         let pin_auth =
-            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 1)
+            pin_uv_auth_protocol::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 1)
                 .unwrap();
         assert_eq!(pin_auth.len(), 16);
         assert_eq!(check, hex::encode(pin_auth).to_uppercase());
@@ -151,7 +152,7 @@ mod tests {
         let check =
             "F0AC99D6AAD2E199AF9CF25F6568A6F555D6394CDC35D81573D71A3B3CB275F3".to_string();
         let pin_auth =
-            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 2)
+            pin_uv_auth_protocol::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 2)
                 .unwrap();
         assert_eq!(pin_auth.len(), 32);
         assert_eq!(check, hex::encode(pin_auth).to_uppercase());
@@ -164,7 +165,7 @@ mod tests {
             hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
                 .unwrap();
         let result =
-            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 3);
+            pin_uv_auth_protocol::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 3);
         assert!(result.is_err());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,14 +125,21 @@ mod tests {
     use std::convert::TryFrom;
     use str_buf::StrBuf;
 
-    #[test]
-    fn test_create_pin_auth_protocol_one() {
-        // PIN/UV Auth Protocol One truncates the HMAC-SHA-256 output to 16 bytes
-        // (CTAP 2.2 6.5.7. authenticate(key, message)).
+    /// Shared HMAC-SHA-256 (key, message) test vector for the
+    /// test_create_pin_auth_protocol_* tests below.
+    fn pin_uv_auth_test_vector() -> (Vec<u8>, Vec<u8>) {
         let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
         let client_data_hash =
             hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
                 .unwrap();
+        (out_bytes, client_data_hash)
+    }
+
+    #[test]
+    fn test_create_pin_auth_protocol_one() {
+        // PIN/UV Auth Protocol One truncates the HMAC-SHA-256 output to 16 bytes
+        // (CTAP 2.2 6.5.7. authenticate(key, message)).
+        let (out_bytes, client_data_hash) = pin_uv_auth_test_vector();
         let check = "F0AC99D6AAD2E199AF9CF25F6568A6F5".to_string();
         let pin_auth =
             pin_uv_auth_protocol::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 1)
@@ -145,10 +152,7 @@ mod tests {
     fn test_create_pin_auth_protocol_two() {
         // PIN/UV Auth Protocol Two returns the full 32-byte HMAC-SHA-256 output
         // without truncation (CTAP 2.2 6.5.8. authenticate(key, message)).
-        let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
-        let client_data_hash =
-            hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
-                .unwrap();
+        let (out_bytes, client_data_hash) = pin_uv_auth_test_vector();
         let check =
             "F0AC99D6AAD2E199AF9CF25F6568A6F555D6394CDC35D81573D71A3B3CB275F3".to_string();
         let pin_auth =
@@ -160,10 +164,7 @@ mod tests {
 
     #[test]
     fn test_create_pin_auth_unknown_protocol() {
-        let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
-        let client_data_hash =
-            hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
-                .unwrap();
+        let (out_bytes, client_data_hash) = pin_uv_auth_test_vector();
         let result =
             pin_uv_auth_protocol::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 3);
         assert!(result.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,14 +125,18 @@ mod tests {
     use str_buf::StrBuf;
 
     #[test]
-    fn test_create_pin_auth() {
+    fn test_create_pin_auth_protocol_one() {
+        // PIN/UV Auth Protocol One truncates the HMAC-SHA-256 output to 16 bytes
+        // (CTAP 2.2 6.5.7. authenticate(key, message)).
         let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
         let client_data_hash =
             hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
                 .unwrap();
         let check = "F0AC99D6AAD2E199AF9CF25F6568A6F5".to_string();
-        let sig = encrypt::enc_hmac_sha_256::authenticate(&out_bytes, &client_data_hash);
-        let pin_auth = sig[0..16].to_vec();
+        let pin_auth =
+            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 1)
+                .unwrap();
+        assert_eq!(pin_auth.len(), 16);
         assert_eq!(check, hex::encode(pin_auth).to_uppercase());
     }
 
@@ -146,9 +150,22 @@ mod tests {
                 .unwrap();
         let check =
             "F0AC99D6AAD2E199AF9CF25F6568A6F555D6394CDC35D81573D71A3B3CB275F3".to_string();
-        let pin_auth = encrypt::enc_hmac_sha_256::authenticate(&out_bytes, &client_data_hash);
+        let pin_auth =
+            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 2)
+                .unwrap();
         assert_eq!(pin_auth.len(), 32);
         assert_eq!(check, hex::encode(pin_auth).to_uppercase());
+    }
+
+    #[test]
+    fn test_create_pin_auth_unknown_protocol() {
+        let out_bytes = hex::decode("1A81CD600A1F6CF4BE5260FE3257B241").unwrap();
+        let client_data_hash =
+            hex::decode("E61E2BD6C4612662960B159CD54CF8EFF1A998C89B3742519D11F85E0F5E7876")
+                .unwrap();
+        let result =
+            encrypt::enc_hmac_sha_256::compute_pin_uv_auth_param(&out_bytes, &client_data_hash, 3);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/pin_uv_auth_protocol.rs
+++ b/src/pin_uv_auth_protocol.rs
@@ -1,4 +1,8 @@
+use crate::encrypt::cose::CoseKey;
 use crate::encrypt::enc_hmac_sha_256;
+use crate::encrypt::shared_secret::SharedSecret;
+use crate::encrypt::shared_secret2::SharedSecret2;
+use crate::pintoken::PinToken;
 use anyhow::{anyhow, Result};
 
 /// The CTAP2 PIN/UV Auth Protocol negotiated with the authenticator.
@@ -41,5 +45,151 @@ pub fn compute_pin_uv_auth_param(
     match protocol {
         PinUvAuthProtocol::One => Ok(sig[0..16].to_vec()),
         PinUvAuthProtocol::Two => Ok(sig),
+    }
+}
+
+/// A PIN/UV Auth Protocol shared secret, in whichever protocol version was negotiated.
+///
+/// Centralizes the Protocol One vs Protocol Two split (key material, encrypt/decrypt,
+/// and HMAC truncation rules) so callers that need a shared secret — for the
+/// pinUvAuthToken flow, PIN set/change, or an extension like hmac-secret — don't have
+/// to re-implement the split themselves.
+#[derive(Debug, Clone)]
+pub enum PinUvAuthSharedSecret {
+    One(SharedSecret),
+    Two(SharedSecret2),
+}
+
+impl Default for PinUvAuthSharedSecret {
+    fn default() -> Self {
+        Self::One(SharedSecret::default())
+    }
+}
+
+impl PinUvAuthSharedSecret {
+    pub fn new(pin_protocol_version: u8, key_agreement: &CoseKey) -> Result<Self> {
+        match PinUvAuthProtocol::from_version(pin_protocol_version)? {
+            PinUvAuthProtocol::One => Ok(Self::One(SharedSecret::new(key_agreement)?)),
+            PinUvAuthProtocol::Two => Ok(Self::Two(SharedSecret2::new(key_agreement)?)),
+        }
+    }
+
+    pub fn public_key(&self) -> &CoseKey {
+        match self {
+            Self::One(s) => &s.public_key,
+            Self::Two(s) => &s.public_key,
+        }
+    }
+
+    pub fn pin_protocol_version(&self) -> u8 {
+        match self {
+            Self::One(_) => PinUvAuthProtocol::One.version(),
+            Self::Two(_) => PinUvAuthProtocol::Two.version(),
+        }
+    }
+
+    /// The key used for authenticate()/HMAC-SHA-256. Protocol Two discards the
+    /// AES-key half of the shared secret, keeping only the HMAC-key half.
+    fn auth_key(&self) -> &[u8] {
+        match self {
+            Self::One(s) => &s.secret,
+            Self::Two(s) => &s.secret[0..32],
+        }
+    }
+
+    /// encrypt(key, demPlaintext) → ciphertext, per the negotiated protocol version.
+    pub fn encrypt(&self, dem_plaintext: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            Self::One(s) => Ok(s.encrypt_raw(dem_plaintext)),
+            Self::Two(s) => s.encrypt(dem_plaintext),
+        }
+    }
+
+    /// decrypt(key, demCiphertext) → plaintext, per the negotiated protocol version.
+    pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            Self::One(s) => Ok(s.decrypt_raw(dem_cipher_text)),
+            Self::Two(s) => s.decrypt(dem_cipher_text),
+        }
+    }
+
+    /// authenticate(key, message) → pinUvAuthParam, per the negotiated protocol version.
+    pub fn authenticate(&self, message: &[u8]) -> Result<Vec<u8>> {
+        compute_pin_uv_auth_param(self.auth_key(), message, self.pin_protocol_version())
+    }
+
+    /// pinHashEnc/pinUvAuthToken encryption of a raw PIN string, per the negotiated
+    /// protocol version's PIN-hashing rule (LEFT(SHA-256(pin), 16), then encrypt()).
+    pub fn encrypt_pin(&self, pin: &str) -> Result<Vec<u8>> {
+        match self {
+            Self::One(s) => Ok(s.encrypt_pin(pin)?.to_vec()),
+            Self::Two(s) => s.encrypt_pin(pin),
+        }
+    }
+
+    /// Decrypt an authenticator-provided pinUvAuthToken ciphertext into a PinToken.
+    pub fn decrypt_token(&self, dem_cipher_text: &[u8]) -> Result<PinToken> {
+        match self {
+            Self::One(s) => s.decrypt_token(dem_cipher_text),
+            Self::Two(s) => s.decrypt_token(dem_cipher_text),
+        }
+    }
+}
+
+#[cfg(test)]
+mod pin_uv_auth_shared_secret_tests {
+    use super::*;
+
+    fn one() -> PinUvAuthSharedSecret {
+        PinUvAuthSharedSecret::One(SharedSecret {
+            secret: [3u8; 32],
+            public_key: CoseKey::default(),
+        })
+    }
+
+    fn two() -> PinUvAuthSharedSecret {
+        let mut secret = [0u8; 64];
+        secret[..32].copy_from_slice(&[1u8; 32]); // HMAC-key half
+        secret[32..].copy_from_slice(&[2u8; 32]); // AES-key half
+        PinUvAuthSharedSecret::Two(SharedSecret2 {
+            secret,
+            public_key: CoseKey::default(),
+        })
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_protocol_versions() {
+        assert_eq!(one().pin_protocol_version(), 1);
+        assert_eq!(two().pin_protocol_version(), 2);
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_encrypt_decrypt_roundtrip() {
+        let salt = [9u8; 32];
+
+        for shared_secret in [one(), two()] {
+            let salt_enc = shared_secret.encrypt(&salt).unwrap();
+            let decrypted = shared_secret.decrypt(&salt_enc).unwrap();
+            assert_eq!(decrypted, salt);
+        }
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_authenticate_length() {
+        let message = [5u8; 32];
+
+        // Protocol One truncates to 16 bytes.
+        let param_one = one().authenticate(&message).unwrap();
+        assert_eq!(param_one.len(), 16);
+
+        // Protocol Two returns the full 32-byte HMAC-SHA-256 output.
+        let param_two = two().authenticate(&message).unwrap();
+        assert_eq!(param_two.len(), 32);
+    }
+
+    #[test]
+    fn test_pin_uv_auth_shared_secret_new_rejects_unknown_protocol() {
+        let result = PinUvAuthSharedSecret::new(3, &CoseKey::default());
+        assert!(result.is_err());
     }
 }

--- a/src/pin_uv_auth_protocol.rs
+++ b/src/pin_uv_auth_protocol.rs
@@ -100,7 +100,7 @@ impl PinUvAuthSharedSecret {
     /// encrypt(key, demPlaintext) → ciphertext, per the negotiated protocol version.
     pub fn encrypt(&self, dem_plaintext: &[u8]) -> Result<Vec<u8>> {
         match self {
-            Self::One(s) => Ok(s.encrypt_raw(dem_plaintext)),
+            Self::One(s) => Ok(s.encrypt(dem_plaintext)),
             Self::Two(s) => s.encrypt(dem_plaintext),
         }
     }
@@ -108,7 +108,7 @@ impl PinUvAuthSharedSecret {
     /// decrypt(key, demCiphertext) → plaintext, per the negotiated protocol version.
     pub fn decrypt(&self, dem_cipher_text: &[u8]) -> Result<Vec<u8>> {
         match self {
-            Self::One(s) => Ok(s.decrypt_raw(dem_cipher_text)),
+            Self::One(s) => Ok(s.decrypt(dem_cipher_text)),
             Self::Two(s) => s.decrypt(dem_cipher_text),
         }
     }
@@ -122,7 +122,7 @@ impl PinUvAuthSharedSecret {
     /// protocol version's PIN-hashing rule (LEFT(SHA-256(pin), 16), then encrypt()).
     pub fn encrypt_pin(&self, pin: &str) -> Result<Vec<u8>> {
         match self {
-            Self::One(s) => Ok(s.encrypt_pin(pin)?.to_vec()),
+            Self::One(s) => s.encrypt_pin(pin),
             Self::Two(s) => s.encrypt_pin(pin),
         }
     }

--- a/src/pin_uv_auth_protocol.rs
+++ b/src/pin_uv_auth_protocol.rs
@@ -1,0 +1,45 @@
+use crate::encrypt::enc_hmac_sha_256;
+use anyhow::{anyhow, Result};
+
+/// The CTAP2 PIN/UV Auth Protocol negotiated with the authenticator.
+/// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#pinProto
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinUvAuthProtocol {
+    One,
+    Two,
+}
+
+impl PinUvAuthProtocol {
+    /// The single source of truth for which pin_protocol_version values are valid.
+    pub fn from_version(pin_protocol_version: u8) -> Result<Self> {
+        match pin_protocol_version {
+            1 => Ok(Self::One),
+            2 => Ok(Self::Two),
+            _ => Err(anyhow!("unknown pin_protocol_version")),
+        }
+    }
+
+    pub fn version(&self) -> u8 {
+        match self {
+            Self::One => 1,
+            Self::Two => 2,
+        }
+    }
+}
+
+/// pinUvAuthParam = authenticate(key, message), per the negotiated PIN/UV Auth Protocol.
+///
+/// - Protocol One (6.5.7. authenticate): LEFT(HMAC-SHA-256(key, message), 16)
+/// - Protocol Two (6.5.8. authenticate): HMAC-SHA-256(key, message) (32 bytes, untruncated)
+pub fn compute_pin_uv_auth_param(
+    key: &[u8],
+    message: &[u8],
+    pin_protocol_version: u8,
+) -> Result<Vec<u8>> {
+    let protocol = PinUvAuthProtocol::from_version(pin_protocol_version)?;
+    let sig = enc_hmac_sha_256::authenticate(key, message);
+    match protocol {
+        PinUvAuthProtocol::One => Ok(sig[0..16].to_vec()),
+        PinUvAuthProtocol::Two => Ok(sig),
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,14 @@
 //
-// cargo test test_main -- --nocapture
+// cargo test test_main -- --nocapture --test-threads=1
+//
+// This runs the suite twice against the connected device: once negotiated to
+// PIN/UV Auth Protocol One, once to Protocol Two (skipping the Protocol Two
+// run for any test if the device doesn't support it). `--test-threads=1` is
+// required so the two runs don't contend for the single physical HID device.
+//
+// To run just one protocol version:
+// cargo test test_main_pin_protocol_one -- --nocapture
+// cargo test test_main_pin_protocol_two -- --nocapture
 //
 // [Be sure to also run the following tests:]
 // cargo run --example test-with-pin-non-rk
@@ -28,6 +37,18 @@ fn is_my_test_key() -> Result<bool> {
     }
 }
 
+/// Create a device negotiated to the given PIN/UV Auth Protocol version.
+/// Returns an ("skipped: ...") Err for protocol 2 if the device doesn't advertise support for it.
+fn create_device_with_pin_protocol(cfg: &Cfg, pin_protocol_version: u8) -> Result<FidoKeyHid> {
+    let mut device = FidoKeyHidFactory::create(cfg)?;
+    if pin_protocol_version == 2 && !device.set_pin_uv_auth_protocol_two()? {
+        return Err(anyhow!(
+            "skipped: device does not support PIN/UV Auth Protocol Two"
+        ));
+    }
+    Ok(device)
+}
+
 fn do_test<F>(f: F)
 where
     F: FnOnce() -> Result<()>,
@@ -45,25 +66,34 @@ where
     println!();
 }
 
-#[test]
-fn test_main() {
-    println!("<<< TEST START >>>");
+fn run_all_tests(pin_protocol_version: u8) {
+    println!("<<< TEST START (PIN/UV Auth Protocol {}) >>>", pin_protocol_version);
 
     do_test(test_get_hid_devices);
     do_test(test_keep_alive_msg_to_stderr_cfg);
     do_test(test_keep_alive_msg_to_stderr_propagates);
     do_test(test_get_info);
     do_test(test_get_info_u2f);
-    do_test(test_client_pin_get_retries);
-    do_test(test_make_credential_with_pin_non_rk);
-    do_test(test_make_credential_with_pin_non_rk_exclude_authenticator);
-    do_test(test_credential_management_get_creds_metadata);
-    do_test(test_credential_management_enumerate_rps);
-    do_test(test_bio_enrollment_get_fingerprint_sensor_info);
-    do_test(test_bio_enrollment_enumerate_enrollments);
+    do_test(|| test_client_pin_get_retries(pin_protocol_version));
+    do_test(|| test_make_credential_with_pin_non_rk(pin_protocol_version));
+    do_test(|| test_make_credential_with_pin_non_rk_exclude_authenticator(pin_protocol_version));
+    do_test(|| test_credential_management_get_creds_metadata(pin_protocol_version));
+    do_test(|| test_credential_management_enumerate_rps(pin_protocol_version));
+    do_test(|| test_bio_enrollment_get_fingerprint_sensor_info(pin_protocol_version));
+    do_test(|| test_bio_enrollment_enumerate_enrollments(pin_protocol_version));
     do_test(test_wink);
 
-    println!("<<< TEST END >>>");
+    println!("<<< TEST END (PIN/UV Auth Protocol {}) >>>", pin_protocol_version);
+}
+
+#[test]
+fn test_main_pin_protocol_one() {
+    run_all_tests(1);
+}
+
+#[test]
+fn test_main_pin_protocol_two() {
+    run_all_tests(2);
 }
 
 #[test]
@@ -253,9 +283,8 @@ fn test_get_info_u2f() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_client_pin_get_retries() -> Result<()> {
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+fn test_client_pin_get_retries(pin_protocol_version: u8) -> Result<()> {
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
 
     let retry = device.get_pin_retries();
     println!("- retries = {:?}", retry);
@@ -271,14 +300,13 @@ fn test_client_pin_get_retries() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_make_credential_with_pin_non_rk() -> Result<()> {
+fn test_make_credential_with_pin_non_rk(pin_protocol_version: u8) -> Result<()> {
     // parameter
     let rpid = "test.com";
     let challenge = b"this is challenge".to_vec();
     let pin = "1234";
 
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
     let att = device.make_credential(rpid, &challenge, Some(pin)).unwrap();
     println!("Attestation");
     println!("{}", att);
@@ -292,14 +320,15 @@ fn test_make_credential_with_pin_non_rk() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_make_credential_with_pin_non_rk_exclude_authenticator() -> Result<()> {
+fn test_make_credential_with_pin_non_rk_exclude_authenticator(
+    pin_protocol_version: u8,
+) -> Result<()> {
     // parameter
     let rpid = "test.com";
     let challenge = b"this is challenge".to_vec();
     let pin = "1234";
 
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
 
     let make_credential_args = MakeCredentialArgsBuilder::new(rpid, &challenge)
         .pin(pin)
@@ -322,9 +351,8 @@ fn test_make_credential_with_pin_non_rk_exclude_authenticator() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_credential_management_get_creds_metadata() -> Result<()> {
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+fn test_credential_management_get_creds_metadata(pin_protocol_version: u8) -> Result<()> {
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
     match device.enable_info_option(&InfoOption::CredMgmt) {
         Ok(result) => {
             if result != Some(true) {
@@ -342,11 +370,10 @@ fn test_credential_management_get_creds_metadata() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_credential_management_enumerate_rps() -> Result<()> {
+fn test_credential_management_enumerate_rps(pin_protocol_version: u8) -> Result<()> {
     let mut cfg = Cfg::init();
     cfg.use_pre_credential_management = false;
-    let device = FidoKeyHidFactory::create(&cfg).unwrap();
+    let device = create_device_with_pin_protocol(&cfg, pin_protocol_version)?;
     match device.enable_info_option(&InfoOption::CredMgmt) {
         Ok(result) => {
             if result != Some(true) {
@@ -364,11 +391,10 @@ fn test_credential_management_enumerate_rps() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_bio_enrollment_get_fingerprint_sensor_info() -> Result<()> {
+fn test_bio_enrollment_get_fingerprint_sensor_info(pin_protocol_version: u8) -> Result<()> {
     let mut skip = true;
 
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
 
     match device.enable_info_option(&InfoOption::UserVerificationMgmtPreview) {
         Ok(result) => {
@@ -395,11 +421,10 @@ fn test_bio_enrollment_get_fingerprint_sensor_info() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_bio_enrollment_enumerate_enrollments() -> Result<()> {
+fn test_bio_enrollment_enumerate_enrollments(pin_protocol_version: u8) -> Result<()> {
     let mut skip = true;
 
-    let device = FidoKeyHidFactory::create(&Cfg::init()).unwrap();
+    let device = create_device_with_pin_protocol(&Cfg::init(), pin_protocol_version)?;
 
     match device.enable_info_option(&InfoOption::UserVerificationMgmtPreview) {
         Ok(result) => {


### PR DESCRIPTION
create_pin_auth now honors pin_protocol_version: for protocol 2 it returns the full 32-byte HMAC-SHA-256 output per CTAP 6.5.8, otherwise it preserves the legacy 16-byte truncation for protocol 1 (6.5.7). Added unit test test_create_pin_auth_protocol_two to verify the 32-byte output and expected value.