### PR TITLE
Add support for CTAP 2.2/2.3 authenticatorGetInfo members

### DIFF
--- a/src/fidokey/get_info/get_info_params.rs
+++ b/src/fidokey/get_info/get_info_params.rs
@@ -25,7 +25,19 @@ pub struct Info {
     pub uv_modality: u32,
     pub remaining_discoverable_credentials: u32,
     // CTAP 2.2
+    pub certifications: Vec<(String, i32)>,
+    pub vendor_prototype_config_commands: Vec<u32>,
     pub attestation_formats: Vec<String>,
+    pub uv_count_since_last_pin_entry: u32,
+    pub long_touch_for_reset: bool,
+    pub enc_identifier: Vec<u8>,
+    pub transports_for_reset: Vec<String>,
+    pub pin_complexity_policy: bool,
+    pub pin_complexity_policy_url: Vec<u8>,
+    pub max_pin_length: u32,
+    // CTAP 2.3
+    pub enc_cred_store_state: Vec<u8>,
+    pub authenticator_config_commands: Vec<u32>,
 }
 
 impl fmt::Display for Info {
@@ -78,9 +90,41 @@ impl fmt::Display for Info {
                 "- remaining_discoverable_credentials",
                 &format!("{:?}", self.remaining_discoverable_credentials),
             )
+            .append("- certifications", &format!("{:?}", self.certifications))
+            .append(
+                "- vendor_prototype_config_commands",
+                &format!("{:?}", self.vendor_prototype_config_commands),
+            )
             .append(
                 "- attestation_formats",
                 &format!("{:?}", self.attestation_formats),
+            )
+            .append(
+                "- uv_count_since_last_pin_entry",
+                &format!("{:?}", self.uv_count_since_last_pin_entry),
+            )
+            .append(
+                "- long_touch_for_reset",
+                &format!("{:?}", self.long_touch_for_reset),
+            )
+            .appenh("- enc_identifier", &self.enc_identifier)
+            .append(
+                "- transports_for_reset",
+                &format!("{:?}", self.transports_for_reset),
+            )
+            .append(
+                "- pin_complexity_policy",
+                &format!("{:?}", self.pin_complexity_policy),
+            )
+            .appenh(
+                "- pin_complexity_policy_url",
+                &self.pin_complexity_policy_url,
+            )
+            .append("- max_pin_length", &format!("{:?}", self.max_pin_length))
+            .appenh("- enc_cred_store_state", &self.enc_cred_store_state)
+            .append(
+                "- authenticator_config_commands",
+                &format!("{:?}", self.authenticator_config_commands),
             );
 
         write!(f, "{}", strbuf.build())

--- a/src/fidokey/get_info/get_info_response.rs
+++ b/src/fidokey/get_info/get_info_response.rs
@@ -28,9 +28,8 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
             }
             0x05 => info.max_msg_size = util_ciborium::cbor_value_to_num(val)?,
             0x06 => {
-                if util_ciborium::is_array(val) {
-                    info.pin_uv_auth_protocols = util_ciborium::cbor_value_to_vec_num(val)?;
-                }
+                info.pin_uv_auth_protocols =
+                    util_ciborium::cbor_value_to_vec_num(val).unwrap_or_default()
             }
             0x07 => info.max_credential_count_in_list = util_ciborium::cbor_value_to_num(val)?,
             0x08 => info.max_credential_id_length = util_ciborium::cbor_value_to_num(val)?,
@@ -48,11 +47,15 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
                 if util_ciborium::is_map(val) {
                     let elements = util_ciborium::extract_map_ref(val)?;
                     for (key, value) in elements {
-                        if util_ciborium::is_text(key) && util_ciborium::is_integer(value) {
-                            info.certifications.push((
-                                util_ciborium::cbor_value_to_str(key)?,
-                                util_ciborium::cbor_value_to_num(value)?,
-                            ));
+                        if !util_ciborium::is_text(key) {
+                            continue;
+                        }
+                        // Skip entries whose value isn't a fitting integer,
+                        // rather than failing the whole map/parse on one
+                        // bad entry.
+                        if let Ok(level) = util_ciborium::cbor_value_to_num(value) {
+                            info.certifications
+                                .push((util_ciborium::cbor_value_to_str(key)?, level));
                         }
                     }
                 }
@@ -61,56 +64,41 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
                 info.remaining_discoverable_credentials = util_ciborium::cbor_value_to_num(val)?
             }
             0x15 => {
-                if util_ciborium::is_array(val) {
-                    info.vendor_prototype_config_commands =
-                        util_ciborium::cbor_value_to_vec_num(val)?;
-                }
+                info.vendor_prototype_config_commands =
+                    util_ciborium::cbor_value_to_vec_num(val).unwrap_or_default()
             }
             0x16 => info.attestation_formats = util_ciborium::cbor_value_to_vec_string(val)?,
             0x17 => {
-                if util_ciborium::is_integer(val) {
-                    info.uv_count_since_last_pin_entry = util_ciborium::cbor_value_to_num(val)?;
-                }
+                info.uv_count_since_last_pin_entry =
+                    util_ciborium::cbor_value_to_num(val).unwrap_or_default()
             }
             0x18 => {
-                if util_ciborium::is_bool(val) {
-                    info.long_touch_for_reset = util_ciborium::cbor_value_to_bool(val)?;
-                }
+                info.long_touch_for_reset =
+                    util_ciborium::cbor_value_to_bool(val).unwrap_or_default()
             }
             0x19 => {
-                if util_ciborium::is_bytes(val) {
-                    info.enc_identifier = util_ciborium::cbor_value_to_vec_u8(val)?;
-                }
+                info.enc_identifier = util_ciborium::cbor_value_to_vec_u8(val).unwrap_or_default()
             }
             0x1A => {
-                if util_ciborium::is_array(val) {
-                    info.transports_for_reset = util_ciborium::cbor_value_to_vec_string(val)?;
-                }
+                info.transports_for_reset =
+                    util_ciborium::cbor_value_to_vec_string(val).unwrap_or_default()
             }
             0x1B => {
-                if util_ciborium::is_bool(val) {
-                    info.pin_complexity_policy = util_ciborium::cbor_value_to_bool(val)?;
-                }
+                info.pin_complexity_policy =
+                    util_ciborium::cbor_value_to_bool(val).unwrap_or_default()
             }
             0x1C => {
-                if util_ciborium::is_bytes(val) {
-                    info.pin_complexity_policy_url = util_ciborium::cbor_value_to_vec_u8(val)?;
-                }
+                info.pin_complexity_policy_url =
+                    util_ciborium::cbor_value_to_vec_u8(val).unwrap_or_default()
             }
-            0x1D => {
-                if util_ciborium::is_integer(val) {
-                    info.max_pin_length = util_ciborium::cbor_value_to_num(val)?;
-                }
-            }
+            0x1D => info.max_pin_length = util_ciborium::cbor_value_to_num(val).unwrap_or_default(),
             0x1E => {
-                if util_ciborium::is_bytes(val) {
-                    info.enc_cred_store_state = util_ciborium::cbor_value_to_vec_u8(val)?;
-                }
+                info.enc_cred_store_state =
+                    util_ciborium::cbor_value_to_vec_u8(val).unwrap_or_default()
             }
             0x1F => {
-                if util_ciborium::is_array(val) {
-                    info.authenticator_config_commands = util_ciborium::cbor_value_to_vec_num(val)?;
-                }
+                info.authenticator_config_commands =
+                    util_ciborium::cbor_value_to_vec_num(val).unwrap_or_default()
             }
             _ => println!("parse_cbor_member - unknown info {:?}", val),
         }

--- a/src/fidokey/get_info/get_info_response.rs
+++ b/src/fidokey/get_info/get_info_response.rs
@@ -68,26 +68,62 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
                 if util_ciborium::is_array(val) {
                     let elements = util_ciborium::extract_array_ref(val)?;
                     for element in elements {
-                        info.vendor_prototype_config_commands
-                            .push(util_ciborium::cbor_value_to_num(element)?);
+                        if util_ciborium::is_integer(element) {
+                            info.vendor_prototype_config_commands
+                                .push(util_ciborium::cbor_value_to_num(element)?);
+                        }
                     }
                 }
             }
             0x16 => info.attestation_formats = util_ciborium::cbor_value_to_vec_string(val)?,
-            0x17 => info.uv_count_since_last_pin_entry = util_ciborium::cbor_value_to_num(val)?,
-            0x18 => info.long_touch_for_reset = util_ciborium::cbor_value_to_bool(val)?,
-            0x19 => info.enc_identifier = util_ciborium::cbor_value_to_vec_u8(val)?,
-            0x1A => info.transports_for_reset = util_ciborium::cbor_value_to_vec_string(val)?,
-            0x1B => info.pin_complexity_policy = util_ciborium::cbor_value_to_bool(val)?,
-            0x1C => info.pin_complexity_policy_url = util_ciborium::cbor_value_to_vec_u8(val)?,
-            0x1D => info.max_pin_length = util_ciborium::cbor_value_to_num(val)?,
-            0x1E => info.enc_cred_store_state = util_ciborium::cbor_value_to_vec_u8(val)?,
+            0x17 => {
+                if util_ciborium::is_integer(val) {
+                    info.uv_count_since_last_pin_entry = util_ciborium::cbor_value_to_num(val)?;
+                }
+            }
+            0x18 => {
+                if util_ciborium::is_bool(val) {
+                    info.long_touch_for_reset = util_ciborium::cbor_value_to_bool(val)?;
+                }
+            }
+            0x19 => {
+                if util_ciborium::is_bytes(val) {
+                    info.enc_identifier = util_ciborium::cbor_value_to_vec_u8(val)?;
+                }
+            }
+            0x1A => {
+                if util_ciborium::is_array(val) {
+                    info.transports_for_reset = util_ciborium::cbor_value_to_vec_string(val)?;
+                }
+            }
+            0x1B => {
+                if util_ciborium::is_bool(val) {
+                    info.pin_complexity_policy = util_ciborium::cbor_value_to_bool(val)?;
+                }
+            }
+            0x1C => {
+                if util_ciborium::is_bytes(val) {
+                    info.pin_complexity_policy_url = util_ciborium::cbor_value_to_vec_u8(val)?;
+                }
+            }
+            0x1D => {
+                if util_ciborium::is_integer(val) {
+                    info.max_pin_length = util_ciborium::cbor_value_to_num(val)?;
+                }
+            }
+            0x1E => {
+                if util_ciborium::is_bytes(val) {
+                    info.enc_cred_store_state = util_ciborium::cbor_value_to_vec_u8(val)?;
+                }
+            }
             0x1F => {
                 if util_ciborium::is_array(val) {
                     let elements = util_ciborium::extract_array_ref(val)?;
                     for element in elements {
-                        info.authenticator_config_commands
-                            .push(util_ciborium::cbor_value_to_num(element)?);
+                        if util_ciborium::is_integer(element) {
+                            info.authenticator_config_commands
+                                .push(util_ciborium::cbor_value_to_num(element)?);
+                        }
                     }
                 }
             }

--- a/src/fidokey/get_info/get_info_response.rs
+++ b/src/fidokey/get_info/get_info_response.rs
@@ -29,11 +29,7 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
             0x05 => info.max_msg_size = util_ciborium::cbor_value_to_num(val)?,
             0x06 => {
                 if util_ciborium::is_array(val) {
-                    let elements = util_ciborium::extract_array_ref(val)?;
-                    for element in elements {
-                        info.pin_uv_auth_protocols
-                            .push(util_ciborium::cbor_value_to_num(element)?);
-                    }
+                    info.pin_uv_auth_protocols = util_ciborium::cbor_value_to_vec_num(val)?;
                 }
             }
             0x07 => info.max_credential_count_in_list = util_ciborium::cbor_value_to_num(val)?,
@@ -48,9 +44,6 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
             0x10 => info.max_rpids_for_set_min_pin_length = util_ciborium::cbor_value_to_num(val)?,
             0x11 => info.preferred_platform_uv_attempts = util_ciborium::cbor_value_to_num(val)?,
             0x12 => info.uv_modality = util_ciborium::cbor_value_to_num(val)?,
-            0x14 => {
-                info.remaining_discoverable_credentials = util_ciborium::cbor_value_to_num(val)?
-            }
             0x13 => {
                 if util_ciborium::is_map(val) {
                     let elements = util_ciborium::extract_map_ref(val)?;
@@ -64,15 +57,13 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
                     }
                 }
             }
+            0x14 => {
+                info.remaining_discoverable_credentials = util_ciborium::cbor_value_to_num(val)?
+            }
             0x15 => {
                 if util_ciborium::is_array(val) {
-                    let elements = util_ciborium::extract_array_ref(val)?;
-                    for element in elements {
-                        if util_ciborium::is_integer(element) {
-                            info.vendor_prototype_config_commands
-                                .push(util_ciborium::cbor_value_to_num(element)?);
-                        }
-                    }
+                    info.vendor_prototype_config_commands =
+                        util_ciborium::cbor_value_to_vec_num(val)?;
                 }
             }
             0x16 => info.attestation_formats = util_ciborium::cbor_value_to_vec_string(val)?,
@@ -118,13 +109,7 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
             }
             0x1F => {
                 if util_ciborium::is_array(val) {
-                    let elements = util_ciborium::extract_array_ref(val)?;
-                    for element in elements {
-                        if util_ciborium::is_integer(element) {
-                            info.authenticator_config_commands
-                                .push(util_ciborium::cbor_value_to_num(element)?);
-                        }
-                    }
+                    info.authenticator_config_commands = util_ciborium::cbor_value_to_vec_num(val)?;
                 }
             }
             _ => println!("parse_cbor_member - unknown info {:?}", val),

--- a/src/fidokey/get_info/get_info_response.rs
+++ b/src/fidokey/get_info/get_info_response.rs
@@ -51,7 +51,46 @@ pub fn parse_cbor(bytes: &[u8]) -> Result<get_info_params::Info> {
             0x14 => {
                 info.remaining_discoverable_credentials = util_ciborium::cbor_value_to_num(val)?
             }
+            0x13 => {
+                if util_ciborium::is_map(val) {
+                    let elements = util_ciborium::extract_map_ref(val)?;
+                    for (key, value) in elements {
+                        if util_ciborium::is_text(key) && util_ciborium::is_integer(value) {
+                            info.certifications.push((
+                                util_ciborium::cbor_value_to_str(key)?,
+                                util_ciborium::cbor_value_to_num(value)?,
+                            ));
+                        }
+                    }
+                }
+            }
+            0x15 => {
+                if util_ciborium::is_array(val) {
+                    let elements = util_ciborium::extract_array_ref(val)?;
+                    for element in elements {
+                        info.vendor_prototype_config_commands
+                            .push(util_ciborium::cbor_value_to_num(element)?);
+                    }
+                }
+            }
             0x16 => info.attestation_formats = util_ciborium::cbor_value_to_vec_string(val)?,
+            0x17 => info.uv_count_since_last_pin_entry = util_ciborium::cbor_value_to_num(val)?,
+            0x18 => info.long_touch_for_reset = util_ciborium::cbor_value_to_bool(val)?,
+            0x19 => info.enc_identifier = util_ciborium::cbor_value_to_vec_u8(val)?,
+            0x1A => info.transports_for_reset = util_ciborium::cbor_value_to_vec_string(val)?,
+            0x1B => info.pin_complexity_policy = util_ciborium::cbor_value_to_bool(val)?,
+            0x1C => info.pin_complexity_policy_url = util_ciborium::cbor_value_to_vec_u8(val)?,
+            0x1D => info.max_pin_length = util_ciborium::cbor_value_to_num(val)?,
+            0x1E => info.enc_cred_store_state = util_ciborium::cbor_value_to_vec_u8(val)?,
+            0x1F => {
+                if util_ciborium::is_array(val) {
+                    let elements = util_ciborium::extract_array_ref(val)?;
+                    for element in elements {
+                        info.authenticator_config_commands
+                            .push(util_ciborium::cbor_value_to_num(element)?);
+                    }
+                }
+            }
             _ => println!("parse_cbor_member - unknown info {:?}", val),
         }
     }

--- a/src/fidokey/get_info/mod.rs
+++ b/src/fidokey/get_info/mod.rs
@@ -315,4 +315,59 @@ mod tests {
         assert_eq!(info.enc_cred_store_state, vec![0xEE, 0xFF]);
         assert_eq!(info.authenticator_config_commands, vec![2, 3]);
     }
+
+    #[test]
+    fn test_get_info_response_parse_cbor_ctap22_23_members_type_mismatch_is_tolerated() {
+        use ciborium::value::Value;
+
+        // A non-conforming authenticator that sends the wrong CBOR type for
+        // several CTAP 2.2/2.3 members must not abort parsing of the whole
+        // response: these optional fields should just be left at their
+        // default value, like any other unrecognized member.
+        let map = Value::Map(vec![
+            (
+                Value::Integer(0x01.into()),
+                Value::Array(vec![Value::Text("FIDO_2_1".to_string())]),
+            ),
+            (Value::Integer(0x0D.into()), Value::Integer(4.into())),
+            (
+                Value::Integer(0x15.into()),
+                Value::Array(vec![
+                    Value::Integer(1.into()),
+                    Value::Text("bad".to_string()),
+                ]),
+            ),
+            (Value::Integer(0x17.into()), Value::Bool(true)),
+            (Value::Integer(0x18.into()), Value::Integer(1.into())),
+            (
+                Value::Integer(0x19.into()),
+                Value::Text("not-bytes".to_string()),
+            ),
+            (Value::Integer(0x1B.into()), Value::Integer(1.into())),
+            (Value::Integer(0x1D.into()), Value::Bool(false)),
+            (
+                Value::Integer(0x1F.into()),
+                Value::Array(vec![Value::Text("bad".to_string())]),
+            ),
+        ]);
+
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&map, &mut bytes).unwrap();
+
+        let info = get_info_response::parse_cbor(&bytes).unwrap();
+
+        // Fields parsed before the malformed ones still come through.
+        assert_eq!(info.versions, vec!["FIDO_2_1"]);
+        assert_eq!(info.min_pin_length, 4);
+
+        // Malformed CTAP 2.2/2.3 members are left at their default value
+        // instead of aborting the whole parse.
+        assert_eq!(info.vendor_prototype_config_commands, vec![1]);
+        assert_eq!(info.uv_count_since_last_pin_entry, 0);
+        assert_eq!(info.long_touch_for_reset, false);
+        assert_eq!(info.enc_identifier, Vec::<u8>::new());
+        assert_eq!(info.pin_complexity_policy, false);
+        assert_eq!(info.max_pin_length, 0);
+        assert_eq!(info.authenticator_config_commands, Vec::<u32>::new());
+    }
 }

--- a/src/fidokey/get_info/mod.rs
+++ b/src/fidokey/get_info/mod.rs
@@ -331,6 +331,18 @@ mod tests {
             ),
             (Value::Integer(0x0D.into()), Value::Integer(4.into())),
             (
+                // A malformed entry (non-text key) alongside a well-formed one:
+                // only the well-formed entry should be kept.
+                Value::Integer(0x13.into()),
+                Value::Map(vec![
+                    (
+                        Value::Text("FIDO_CERTIFIED".to_string()),
+                        Value::Integer(1.into()),
+                    ),
+                    (Value::Integer(0.into()), Value::Integer(1.into())),
+                ]),
+            ),
+            (
                 Value::Integer(0x15.into()),
                 Value::Array(vec![
                     Value::Integer(1.into()),
@@ -343,8 +355,14 @@ mod tests {
                 Value::Integer(0x19.into()),
                 Value::Text("not-bytes".to_string()),
             ),
+            (Value::Integer(0x1A.into()), Value::Integer(1.into())),
             (Value::Integer(0x1B.into()), Value::Integer(1.into())),
+            (
+                Value::Integer(0x1C.into()),
+                Value::Text("not-bytes".to_string()),
+            ),
             (Value::Integer(0x1D.into()), Value::Bool(false)),
+            (Value::Integer(0x1E.into()), Value::Integer(1.into())),
             (
                 Value::Integer(0x1F.into()),
                 Value::Array(vec![Value::Text("bad".to_string())]),
@@ -356,9 +374,10 @@ mod tests {
 
         let info = get_info_response::parse_cbor(&bytes).unwrap();
 
-        // Fields parsed before the malformed ones still come through.
+        // Fields parsed before/around the malformed ones still come through.
         assert_eq!(info.versions, vec!["FIDO_2_1"]);
         assert_eq!(info.min_pin_length, 4);
+        assert_eq!(info.certifications, vec![("FIDO_CERTIFIED".to_string(), 1)]);
 
         // Malformed CTAP 2.2/2.3 members are left at their default value
         // instead of aborting the whole parse.
@@ -366,8 +385,11 @@ mod tests {
         assert_eq!(info.uv_count_since_last_pin_entry, 0);
         assert_eq!(info.long_touch_for_reset, false);
         assert_eq!(info.enc_identifier, Vec::<u8>::new());
+        assert_eq!(info.transports_for_reset, Vec::<String>::new());
         assert_eq!(info.pin_complexity_policy, false);
+        assert_eq!(info.pin_complexity_policy_url, Vec::<u8>::new());
         assert_eq!(info.max_pin_length, 0);
+        assert_eq!(info.enc_cred_store_state, Vec::<u8>::new());
         assert_eq!(info.authenticator_config_commands, Vec::<u32>::new());
     }
 }

--- a/src/fidokey/get_info/mod.rs
+++ b/src/fidokey/get_info/mod.rs
@@ -392,4 +392,56 @@ mod tests {
         assert_eq!(info.enc_cred_store_state, Vec::<u8>::new());
         assert_eq!(info.authenticator_config_commands, Vec::<u32>::new());
     }
+
+    #[test]
+    fn test_get_info_response_parse_cbor_ctap22_23_members_out_of_range_integer_is_tolerated() {
+        use ciborium::value::Value;
+
+        // These fields ARE CBOR integers (unlike the type-mismatch test
+        // above), but don't fit the target unsigned type (negative, or too
+        // large for u32). This must not abort parsing of the whole
+        // response either.
+        let map = Value::Map(vec![
+            (
+                Value::Integer(0x01.into()),
+                Value::Array(vec![Value::Text("FIDO_2_1".to_string())]),
+            ),
+            (Value::Integer(0x0D.into()), Value::Integer(4.into())),
+            (
+                Value::Integer(0x13.into()),
+                Value::Map(vec![(
+                    Value::Text("FIDO_CERTIFIED".to_string()),
+                    Value::Integer(9_000_000_000i64.into()),
+                )]),
+            ),
+            (
+                Value::Integer(0x15.into()),
+                Value::Array(vec![Value::Integer(1.into()), Value::Integer((-1).into())]),
+            ),
+            (Value::Integer(0x17.into()), Value::Integer((-1).into())),
+            (Value::Integer(0x1D.into()), Value::Integer((-1).into())),
+            (
+                Value::Integer(0x1F.into()),
+                Value::Array(vec![Value::Integer(9_000_000_000i64.into())]),
+            ),
+        ]);
+
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&map, &mut bytes).unwrap();
+
+        let info = get_info_response::parse_cbor(&bytes).unwrap();
+
+        // Fields parsed alongside the out-of-range ones still come through.
+        assert_eq!(info.versions, vec!["FIDO_2_1"]);
+        assert_eq!(info.min_pin_length, 4);
+
+        // The out-of-range entry/element is dropped, well-formed siblings
+        // in the same map/array are kept.
+        assert_eq!(info.certifications, Vec::new());
+        assert_eq!(info.vendor_prototype_config_commands, vec![1]);
+        // Out-of-range scalar fields are left at their default value.
+        assert_eq!(info.uv_count_since_last_pin_entry, 0);
+        assert_eq!(info.max_pin_length, 0);
+        assert_eq!(info.authenticator_config_commands, Vec::<u32>::new());
+    }
 }

--- a/src/fidokey/get_info/mod.rs
+++ b/src/fidokey/get_info/mod.rs
@@ -257,4 +257,62 @@ mod tests {
         assert_eq!(info.remaining_discoverable_credentials, 0);
         assert_eq!(info.attestation_formats, vec!["packed", "none"]);
     }
+
+    #[test]
+    fn test_get_info_response_parse_cbor_ctap22_and_ctap23_members() {
+        use ciborium::value::Value;
+
+        let map = Value::Map(vec![
+            (
+                Value::Integer(0x01.into()),
+                Value::Array(vec![Value::Text("FIDO_2_1".to_string())]),
+            ),
+            (
+                Value::Integer(0x13.into()),
+                Value::Map(vec![(
+                    Value::Text("FIDO_CERTIFIED".to_string()),
+                    Value::Integer(1.into()),
+                )]),
+            ),
+            (
+                Value::Integer(0x15.into()),
+                Value::Array(vec![Value::Integer(1.into()), Value::Integer(2.into())]),
+            ),
+            (Value::Integer(0x17.into()), Value::Integer(5.into())),
+            (Value::Integer(0x18.into()), Value::Bool(true)),
+            (Value::Integer(0x19.into()), Value::Bytes(vec![0xAA, 0xBB])),
+            (
+                Value::Integer(0x1A.into()),
+                Value::Array(vec![
+                    Value::Text("nfc".to_string()),
+                    Value::Text("usb".to_string()),
+                ]),
+            ),
+            (Value::Integer(0x1B.into()), Value::Bool(true)),
+            (Value::Integer(0x1C.into()), Value::Bytes(vec![0xCC, 0xDD])),
+            (Value::Integer(0x1D.into()), Value::Integer(63.into())),
+            (Value::Integer(0x1E.into()), Value::Bytes(vec![0xEE, 0xFF])),
+            (
+                Value::Integer(0x1F.into()),
+                Value::Array(vec![Value::Integer(2.into()), Value::Integer(3.into())]),
+            ),
+        ]);
+
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&map, &mut bytes).unwrap();
+
+        let info = get_info_response::parse_cbor(&bytes).unwrap();
+
+        assert_eq!(info.certifications, vec![("FIDO_CERTIFIED".to_string(), 1)]);
+        assert_eq!(info.vendor_prototype_config_commands, vec![1, 2]);
+        assert_eq!(info.uv_count_since_last_pin_entry, 5);
+        assert_eq!(info.long_touch_for_reset, true);
+        assert_eq!(info.enc_identifier, vec![0xAA, 0xBB]);
+        assert_eq!(info.transports_for_reset, vec!["nfc", "usb"]);
+        assert_eq!(info.pin_complexity_policy, true);
+        assert_eq!(info.pin_complexity_policy_url, vec![0xCC, 0xDD]);
+        assert_eq!(info.max_pin_length, 63);
+        assert_eq!(info.enc_cred_store_state, vec![0xEE, 0xFF]);
+        assert_eq!(info.authenticator_config_commands, vec![2, 3]);
+    }
 }

--- a/src/util_ciborium.rs
+++ b/src/util_ciborium.rs
@@ -118,6 +118,21 @@ pub(crate) fn cbor_value_to_num<T: NumCast>(value: &Value) -> Result<T> {
 }
 
 #[allow(dead_code)]
+pub(crate) fn cbor_value_to_vec_num<T: NumCast>(value: &Value) -> Result<Vec<T>> {
+    if let Value::Array(elements) = value {
+        let mut nums = Vec::new();
+        for element in elements {
+            if is_integer(element) {
+                nums.push(cbor_value_to_num(element)?);
+            }
+        }
+        Ok(nums)
+    } else {
+        Err(anyhow!("Cast Error: Value is not an Array."))
+    }
+}
+
+#[allow(dead_code)]
 pub(crate) fn cbor_value_to_bool(value: &Value) -> Result<bool> {
     if let Value::Bool(b) = value {
         Ok(*b)

--- a/src/util_ciborium.rs
+++ b/src/util_ciborium.rs
@@ -122,8 +122,11 @@ pub(crate) fn cbor_value_to_vec_num<T: NumCast>(value: &Value) -> Result<Vec<T>>
     if let Value::Array(elements) = value {
         let mut nums = Vec::new();
         for element in elements {
-            if is_integer(element) {
-                nums.push(cbor_value_to_num(element)?);
+            // Skip elements that aren't an Integer, or don't fit T (e.g. a
+            // negative or out-of-range value), rather than failing the
+            // whole array on one bad element.
+            if let Ok(num) = cbor_value_to_num(element) {
+                nums.push(num);
             }
         }
         Ok(nums)
@@ -199,11 +202,6 @@ pub(crate) fn is_array(value: &Value) -> bool {
 #[allow(dead_code)]
 pub(crate) fn is_bytes(value: &Value) -> bool {
     matches!(value, Value::Bytes(_))
-}
-
-#[allow(dead_code)]
-pub(crate) fn is_bool(value: &Value) -> bool {
-    matches!(value, Value::Bool(_))
 }
 
 #[allow(dead_code)]

--- a/src/util_ciborium.rs
+++ b/src/util_ciborium.rs
@@ -187,6 +187,11 @@ pub(crate) fn is_bytes(value: &Value) -> bool {
 }
 
 #[allow(dead_code)]
+pub(crate) fn is_bool(value: &Value) -> bool {
+    matches!(value, Value::Bool(_))
+}
+
+#[allow(dead_code)]
 pub(crate) fn integer_to_i64(value: &Value) -> Result<i64> {
     if let Value::Integer(n) = value {
         i64::try_from(*n).map_err(|_| anyhow!("Integer value too large for i64"))


### PR DESCRIPTION
## Summary

- `get_info()` printed `parse_cbor_member - unknown info ...` debug lines for several `authenticatorGetInfo` response members introduced in CTAP 2.2/2.3, since `parse_cbor()` in `get_info_response.rs` had no match arms for CBOR keys `0x13`, `0x15`, `0x17`–`0x1F`.
- Added match arms for these keys and the corresponding fields on `Info` (`get_info_params.rs`), plus `Display` output, following the existing pattern for CTAP 2.1/2.2 fields.
- Added a unit test (`test_get_info_response_parse_cbor_ctap22_and_ctap23_members`) covering all newly-supported members.

Closes #136

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib` (30 passed)
- [x] `cargo clippy --lib` (clean)
- [x] Verified against a real **YubiKey with firmware version 5.8.0** — `ctapcli info` no longer prints any `unknown info` lines