### PR TITLE
fix: correct get_assertion_with_extensios to get_assertion_with_extensions

### DIFF
--- a/src/fidokey/get_assertion/mod.rs
+++ b/src/fidokey/get_assertion/mod.rs
@@ -82,7 +82,7 @@ impl FidoKeyHid {
     }
 
     /// Authentication command(with PIN , non Resident Key , Extension)
-    pub fn get_assertion_with_extensios(
+    pub fn get_assertion_with_extensions(
         &self,
         rpid: &str,
         challenge: &[u8],


### PR DESCRIPTION
## Summary
Corrects a typo in the public method name: `get_assertion_with_extensios` → `get_assertion_with_extensions` in FidoKeyHid.

Fixes issue #141.